### PR TITLE
Add:X(旧Twitter)投稿機能実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'sorcery', '~> 0.16.5'
 gem 'pry-byebug'
 gem 'cssbundling-rails'
 gem 'ransack'
+gem 'twitter'
+gem 'dotenv-rails', groups: [:development, :test]
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
+    buftok (0.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.39.2)
@@ -104,17 +105,35 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    domain_name (0.6.20240107)
+    dotenv (3.1.0)
+    dotenv-rails (3.1.0)
+      dotenv (= 3.1.0)
+      railties (>= 6.1)
     drb (2.2.0)
       ruby2_keywords
+    equalizer (0.0.11)
     erubi (1.12.0)
     faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    ffi (1.16.3)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.3)
@@ -129,6 +148,9 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jwt (2.7.1)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -139,12 +161,16 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    multipart-post (2.4.0)
     mutex_m (0.2.0)
+    naught (1.1.0)
     net-imap (0.4.7)
       date
       net-protocol
@@ -239,6 +265,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simple_oauth (0.3.1)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -257,11 +284,23 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.0)
+    thread_safe (0.3.6)
     timeout (0.4.1)
     turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
+    twitter (8.0.1)
+      addressable (~> 2.3)
+      buftok (~> 0.3.0)
+      equalizer (~> 0.0.11)
+      http (~> 5.1)
+      http-form_data (~> 2.3)
+      llhttp-ffi (~> 0.4.0)
+      memoizable (~> 0.4.0)
+      multipart-post (~> 2.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     version_gem (1.1.3)
@@ -288,6 +327,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)
@@ -300,6 +340,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
+  twitter
   tzinfo-data
   web-console
 

--- a/app/models/concerns/twitter_client.rb
+++ b/app/models/concerns/twitter_client.rb
@@ -1,0 +1,16 @@
+require 'twitter'
+
+module TwitterClient
+  def self.client
+    @client ||= Twitter::REST::Client.new do |config|
+      config.consumer_key        = ENV["TWITTER_CONSUMER_KEY"]
+      config.consumer_secret     = ENV["TWITTER_CONSUMER_SECRET"]
+      config.access_token        = ENV["TWITTER_ACCESS_TOKEN"]
+      config.access_token_secret = ENV["TWITTER_ACCESS_SECRET"]
+    end
+  end
+
+  def self.post_to_twitter(message)
+    client.update(message)
+  end
+end

--- a/app/models/match_info.rb
+++ b/app/models/match_info.rb
@@ -6,6 +6,7 @@ class MatchInfo < ApplicationRecord
   has_many :scores, dependent: :destroy
   accepts_nested_attributes_for :scores, update_only: true
   has_many :games
+  attr_accessor :post_to_x
 
   def self.ransackable_attributes(auth_object = nil)
     ["match_name", "player_id", "opponent_id"]

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -73,6 +73,11 @@
         <% end %>
       <% end %>
     <% end %>
+    
+    <div class="mb-3">
+    <%= form.label :post_to_x, "Xに投稿する" %>
+    <%= form.check_box :post_to_x %>
+    </div>
 
     <div class="center-text">
       <%= form.submit "試合を分析する", class: "btn btn-success text-white" %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,5 @@ services:
       - "3000:3000"
     depends_on:
       - db
+    env_file:
+      - ./.env


### PR DESCRIPTION
## 概要
X Developer Portalに登録し、API KeyとSecret Key、Access Token KeyとAccess Secret Keyを発行しました。
次にtwitter gemとdotenv-rails gemをbundle installし、.envファイルに環境変数を設定しました。
次にtwitter_client.rbファイルを作成し、TwitterClient モジュール内にクライアントの設定と投稿メソッドを定義しました。
次に試合分析データを保存するフォームにXに投稿するかどうか選択できるチェックボックスを作成しました。
最後にコントローラーにチェックボックスが選択された状態で試合分析データが保存された場合は保存データがXに投稿されるように条件分岐を実装しました。

## コメント
現在Herokuのアプリケーションエラーが出ており、本番環境で投稿が正常に行えるか確認できていない状況なのでHerokuエラーを解消してから投稿機能が正常に動作するか確認したいと思います。
また、試合の情報に対戦相手の名前も載ることになるのでそもそも現在開発しているWebアプリにXへの投稿機能が必要なのかどうか疑問に思ってきています。
