### PR TITLE
Add : 試合分析フォームと試合分析編集フォームのバリデーション強化

### DIFF
--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -67,6 +67,7 @@ class MatchInfosController < ApplicationController
         format.html { redirect_to @match_info, notice: "試合分析データが更新されました。" }
         format.json { render :show, status: :ok, location: @match_info }
       else
+        Rails.logger.info(@match_info.errors.full_messages)
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @match_info.errors, status: :unprocessable_entity }
       end
@@ -98,6 +99,6 @@ class MatchInfosController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def match_info_params
-      params.require(:match_info).permit(:match_date, :match_name, :memo , :post_to_x, scores_attributes: [:id, :batting_style, :score, :lost_score])
+      params.require(:match_info).permit(:match_date, :match_name, :memo , :post_to_x, scores_attributes: [:id, :batting_style, :score, :lost_score, :_destroy])
     end
 end

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -63,7 +63,10 @@ class MatchInfosController < ApplicationController
   def update
     player = Player.find_or_create_by(player_name: params[:match_info][:player_name])
     opponent = Player.find_or_create_by(player_name: params[:match_info][:opponent_name])
-  
+
+    @match_info.player_name = params[:match_info][:player_name]
+    @match_info.opponent_name = params[:match_info][:opponent_name]
+
     respond_to do |format|
       if @match_info.update(match_info_params.merge(player_id: player.id, opponent_id: opponent.id))
         format.html { redirect_to @match_info, notice: "試合分析データが更新されました。" }

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -37,7 +37,9 @@ class MatchInfosController < ApplicationController
     opponent = Player.find_or_create_by(player_name: params[:match_info][:opponent_name])
   
     @match_info = MatchInfo.new(match_info_params.merge(player_id: player.id, opponent_id: opponent.id))
-  
+    @match_info.player_name = params[:match_info][:player_name]
+    @match_info.opponent_name = params[:match_info][:opponent_name]
+
     @match_info.user = current_user
   
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,6 @@ class UsersController < ApplicationController
     if @user.save
       redirect_to login_path, notice: "会員登録が完了しました"
     else
-      Rails.logger.info(@user.errors.full_messages)
       render :new
     end
   end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,5 +1,7 @@
-import { Application } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
+Turbo.start()
 
+import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience

--- a/app/models/match_info.rb
+++ b/app/models/match_info.rb
@@ -30,4 +30,5 @@ class MatchInfo < ApplicationRecord
   def self.opponent_player_name_cont(query)
     joins(:opponent).where("players.player_name LIKE ?", "%#{query}%")
   end
+
 end

--- a/app/models/match_info.rb
+++ b/app/models/match_info.rb
@@ -2,17 +2,26 @@ class MatchInfo < ApplicationRecord
   belongs_to :user
   belongs_to :player, class_name: "Player", foreign_key: "player_id"
   belongs_to :opponent, class_name: "Player", foreign_key: "opponent_id"
-  attr_accessor :player_name, :opponent_name
   has_many :scores, dependent: :destroy
   accepts_nested_attributes_for :scores, update_only: true
   has_many :games
+  attr_accessor :player_name, :opponent_name
   attr_accessor :post_to_x
 
   validates :match_date, presence: true
   validates :match_name, presence: true
-  validates :player_name, presence: true
-  validates :opponent_name, presence: true
   validates :memo, length: { maximum: 500, message: "は500文字以内で入力してください" }, allow_blank: true
+  validate :validate_player_and_opponent_names
+
+  def validate_player_and_opponent_names
+    if player_name.blank?
+      errors.add(:player_name, "を入力してください")
+    end
+
+    if opponent_name.blank?
+      errors.add(:opponent_name, "を入力してください")
+    end
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     ["match_name", "player_id", "opponent_id"]
@@ -30,5 +39,4 @@ class MatchInfo < ApplicationRecord
   def self.opponent_player_name_cont(query)
     joins(:opponent).where("players.player_name LIKE ?", "%#{query}%")
   end
-
 end

--- a/app/models/match_info.rb
+++ b/app/models/match_info.rb
@@ -8,6 +8,12 @@ class MatchInfo < ApplicationRecord
   has_many :games
   attr_accessor :post_to_x
 
+  validates :match_date, presence: true
+  validates :match_name, presence: true
+  validates :player_name, presence: true
+  validates :opponent_name, presence: true
+  validates :memo, length: { maximum: 500, message: "は500文字以内で入力してください" }, allow_blank: true
+
   def self.ransackable_attributes(auth_object = nil)
     ["match_name", "player_id", "opponent_id"]
   end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -4,4 +4,13 @@ class Score < ApplicationRecord
 
   enum batting_style: { serve: 0, receive: 1}
 
+  validate :score_or_lost_score_must_be_positive_for_serve_and_receive
+
+  private
+
+  def score_or_lost_score_must_be_positive_for_serve_and_receive
+    if (serve? || receive?) && score <= 0 && lost_score <= 0
+      errors.add(:base, "サーブとレシーブそれぞれの得点数または失点数を1以上にしてください")
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <%= javascript_include_tag "application", type: "module" %>
 
     <%= favicon_link_tag asset_path('favicon-32x32.png') %>
 

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -1,16 +1,7 @@
 <div class="form-container">
   <%= form_with(model: match_info) do |form| %>
-    <% if match_info.errors.any? %>
-      <div style="color: red">
-        <h2><%= pluralize(match_info.errors.count, "error") %> prohibited this match_info from being saved:</h2>
-
-        <ul>
-          <% match_info.errors.each do |error| %>
-            <li><%= error.full_message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+  
+    <%= render 'shared/error_messages', object: @match_info %>
 
     <div class="row mb-3">
       <div class="column">

--- a/app/views/match_infos/_form_edit.html.erb
+++ b/app/views/match_infos/_form_edit.html.erb
@@ -1,16 +1,7 @@
 <div class="form-container">
   <%= form_with(model: match_info) do |form| %>
-    <% if match_info.errors.any? %>
-      <div style="color: red">
-        <h2><%= pluralize(match_info.errors.count, "error") %> prohibited this match_info from being saved:</h2>
 
-        <ul>
-          <% match_info.errors.each do |error| %>
-            <li><%= error.full_message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render 'shared/error_messages', object: @match_info %>
 
     <div class="row mb-3">
       <div class="column">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -4,9 +4,24 @@
 <% if object.errors.any? %>
   <div class="alert alert-danger">
     <ul>
+      <% important_errors = ["日付を入力してください", "大会名を入力してください", "選手名を入力してください", "対戦相手名を入力してください"] %>
+
+      <% important_errors.each do |important_message| %>
+        <% if object.errors.full_messages.include?(important_message) %>
+          <li><%= important_message %></li>
+        <% end %>
+      <% end %>
+
       <% object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <% unless important_errors.include?(message) %>
+          <% if message.exclude?("Scores") %>
+            <li><%= message %></li>
+          <% else %>
+            <li><%= message.gsub("Scores", "") %></li>
+          <% end %>
+        <% end %>
       <% end %>
     </ul>
   </div>
 <% end %>
+

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -22,3 +22,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "application", type: "module" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -30,3 +30,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_include_tag "application", type: "module" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,3 +8,9 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード確認
+      match_info:
+        match_date: "日付"
+        match_name: "大会名"
+        player_name: "選手名"
+        opponent_name: "対戦相手名"
+        memo: "メモ"

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -7,6 +7,7 @@
   "linkedModules": [],
   "topLevelPatterns": [
     "@hotwired/stimulus@^3.2.2",
+    "@hotwired/turbo-rails@^8.0.9",
     "@popperjs/core@^2.11.8",
     "autoprefixer@^10.4.17",
     "bootstrap-icons@^1.11.3",
@@ -19,11 +20,14 @@
   ],
   "lockfileEntries": {
     "@hotwired/stimulus@^3.2.2": "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608",
+    "@hotwired/turbo-rails@^8.0.9": "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.9.tgz#e18f4035dab26c6c12f17245225e9f3a89fd6216",
+    "@hotwired/turbo@^8.0.6": "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.6.tgz#d7c546f7700f18ebfe4d1b106e03c9ed1bb22887",
     "@nodelib/fs.scandir@2.1.5": "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5",
     "@nodelib/fs.stat@2.0.5": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b",
     "@nodelib/fs.stat@^2.0.2": "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b",
     "@nodelib/fs.walk@^1.2.3": "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a",
     "@popperjs/core@^2.11.8": "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f",
+    "@rails/actioncable@^7.0": "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.100.tgz#86ec1c2e00c357cef1e421fd63863d5c34339ce8",
     "@sindresorhus/merge-streams@^1.0.0": "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz#9cd84cc15bc865a5ca35fcaae198eb899f7b5c90",
     "abbrev@1": "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8",
     "ansi-regex@^5.0.1": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^8.0.9",
     "@popperjs/core": "^2.11.8",
     "autoprefixer": "^10.4.17",
     "bootstrap": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,19 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
 
+"@hotwired/turbo-rails@^8.0.9":
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.9.tgz#e18f4035dab26c6c12f17245225e9f3a89fd6216"
+  integrity sha512-yJWcKjztrerWYIiinv/febJlVzsOfih2s4eGAoHmg0XvWkGhzWqupknByt18Jo5NfbZgCdeWlUH3q818Ay7FOQ==
+  dependencies:
+    "@hotwired/turbo" "^8.0.6"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^8.0.6":
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.6.tgz#d7c546f7700f18ebfe4d1b106e03c9ed1bb22887"
+  integrity sha512-mwZRfwcJ4yatUnW5tcCY9NDvo0kjuuLQF/y8pXigHhS+c/JY/ccNluVyuERR9Sraqx0qdpenkO3pNeSWz1mE3w==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -32,6 +45,11 @@
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
+"@rails/actioncable@^7.0":
+  version "7.2.100"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.100.tgz#86ec1c2e00c357cef1e421fd63863d5c34339ce8"
+  integrity sha512-7xtIENf0Yw59AFDM3+xqxPCZxev3QVAqjPmUzmgsB9eL8S/zTpB0IU9srNc7XknzJI4e09XKNnCaJRx3gfYzXA==
 
 "@sindresorhus/merge-streams@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## 概要
試合分析フォームと試合分析編集フォームにメモは500文字以内、それ以外の項目は入力しないと分析データを保存できないようにバリデーションを設定しました。

[![Image from Gyazo](https://i.gyazo.com/5c91ec0478d50bd4728d6d8445ebacc5.png)](https://gyazo.com/5c91ec0478d50bd4728d6d8445ebacc5)

[![Image from Gyazo](https://i.gyazo.com/2be723f294746bf315dbb591e6b8a18f.png)](https://gyazo.com/2be723f294746bf315dbb591e6b8a18f)

Closes #33
