### PR TITLE
試合分析フォームの使い方を明確化

### DIFF
--- a/app/assets/stylesheets/match_infos.scss
+++ b/app/assets/stylesheets/match_infos.scss
@@ -5,6 +5,11 @@
   margin-bottom: 20px;
 }
 
+/* 分析ページサブタイトル */
+.center-subtext {
+  text-align: center;
+}
+
 /* ページ遷移リンク */
 .center-link {
   text-align: center;

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -11,25 +11,34 @@
 
       <div class="column">
         <%= form.label :"大会名", style: "display: block" %>
-        <%= form.text_field :match_name %>
+        <%= form.text_field :match_name, placeholder: "出場した大会名を入力" %>
       </div>
     </div>
 
     <div class="row mb-3">
       <div class="column">
         <%= form.label :"選手名", style: "display: block" %>
-        <%= form.text_field :player_name %>
+        <%= form.text_field :player_name, placeholder: "分析する選手名を入力" %>
       </div>
 
       <div class="column">
         <%= form.label :"対戦相手名", style: "display: block" %>
-        <%= form.text_field :opponent_name %>
+        <%= form.text_field :opponent_name, placeholder: "対戦相手の名前を入力" %>
       </div>
     </div>
 
-    <div class="mb-3">
+    <div class="mb-5">
       <%= form.label :"メモ", style: "display: block" %>
-      <%= form.text_area :memo, class: "wide-textarea" %>
+      <%= form.text_area :memo, class: "wide-textarea", placeholder: "対戦相手の戦型や使用用具、分析していて気になったプレーなどを入力" %>
+    </div>
+
+    <div class="analysis-header mb-4">
+      <h4 class="center-subtext">【サーブとレシーブからの得点率分析】</h4>
+      <div>サーブとレシーブそれぞれから始まったラリーの得点率を分析します。<br>
+        例：分析する選手のサーブから始まったラリーで得点<br>→サーブの得点数に1をプラスする。<br>
+        ※サービスエースとレシーブエースのみを集計するためのものではありません。<br>
+        ※得点数/失点数は選手の視点で入力
+      </div>
     </div>
 
     <% match_info.scores.each do |score| %>
@@ -37,7 +46,7 @@
         <%= score_form.select :batting_style, [['サーブ', 'serve'], ['レシーブ', 'receive']], {}, { class: "form-control medium-input" } %>
 
         <% if score.batting_style == "serve" %>
-          <div class="row mb-3">
+          <div class="row mb-5">
             <div class="column">
               <%= score_form.label :score, "得点数", class: "text-blue" %>
               <div class="number-input d-flex align-items-center">
@@ -56,7 +65,7 @@
             </div>
           </div>
         <% elsif score.batting_style == "receive" %>
-          <div class="row mb-3">
+          <div class="row mb-5">
             <div class="column">
               <%= score_form.label :score, "得点数", class: "text-blue" %>
               <div class="number-input d-flex align-items-center">

--- a/app/views/match_infos/_form_edit.html.erb
+++ b/app/views/match_infos/_form_edit.html.erb
@@ -11,25 +11,34 @@
 
       <div class="column">
         <%= form.label :"大会名", style: "display: block" %>
-        <%= form.text_field :match_name %>
+        <%= form.text_field :match_name, placeholder: "出場した大会名を入力" %>
       </div>
     </div>
 
     <div class="row mb-3">
       <div class="column">
         <%= form.label :"選手名", style: "display: block" %>
-        <%= form.text_field :player_name %>
+        <%= form.text_field :player_name, placeholder: "分析する選手名を入力" %>
       </div>
 
       <div class="column">
         <%= form.label :"対戦相手名", style: "display: block" %>
-        <%= form.text_field :opponent_name %>
+        <%= form.text_field :opponent_name, placeholder: "対戦相手の名前を入力" %>
       </div>
     </div>
 
-    <div class="column">
+    <div class="mb-5">
       <%= form.label :"メモ", style: "display: block" %>
-      <%= form.text_area :memo, class: "wide-textarea" %>
+      <%= form.text_area :memo, class: "wide-textarea", placeholder: "対戦相手の戦型や使用用具、分析していて気になったプレーなどを入力" %>
+    </div>
+
+    <div class="analysis-header mb-4">
+      <h4 class="center-subtext">【サーブとレシーブからの得点率分析】</h4>
+      <div>サーブとレシーブそれぞれから始まったラリーの得点率を分析します。<br>
+        例：分析する選手のサーブから始まったラリーで得点<br>→サーブの得点数に1をプラスする。<br>
+        ※サービスエースとレシーブエースのみを集計するためのものではありません。<br>
+        ※得点数/失点数は選手の視点で入力
+      </div>
     </div>
 
     <% if match_info.scores.present? %>
@@ -38,7 +47,7 @@
           <%= score_form.select :batting_style, [['サーブ', 'serve'], ['レシーブ', 'receive']], {}, { class: "form-control medium-input" } %>
 
           <% if score_form.object.batting_style == "serve" %>
-            <div class="row mb-3">
+            <div class="row mb-5">
               <div class="column">
                 <%= score_form.label :score, "得点数", class: "text-blue" %>
                 <div class="number-input d-flex align-items-center">
@@ -58,7 +67,7 @@
             </div>
           <% elsif score_form.object.batting_style == "receive" %>
             <!-- 同様のコードを"receive"の場合にも適用 -->
-            <div class="row mb-3">
+            <div class="row mb-5">
               <div class="column">
                 <%= score_form.label :score, "得点数", class: "text-blue" %>
                 <div class="number-input d-flex align-items-center">

--- a/app/views/match_infos/new.html.erb
+++ b/app/views/match_infos/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="center-text">試合分析</h1>
+<h1 class="center-text">試合分析フォーム</h1>
 
 <%= render "form", match_info: @match_info %>
 


### PR DESCRIPTION
## 概要
ユーザーが分析フォームを入力する際に混乱しないようにplaceholderと説明文を追加しました。
またフォーム同士が近すぎる部分があったので空白も少し調整しました。

# before
[![Image from Gyazo](https://i.gyazo.com/60b7c8e128a2d76d6b81846cdaca03ba.png)](https://gyazo.com/60b7c8e128a2d76d6b81846cdaca03ba)

[![Image from Gyazo](https://i.gyazo.com/5dc2bbca043380317d1c332e215375f3.png)](https://gyazo.com/5dc2bbca043380317d1c332e215375f3)

# after
[![Image from Gyazo](https://i.gyazo.com/36a09eace7137b03157e00df0aa6b235.png)](https://gyazo.com/36a09eace7137b03157e00df0aa6b235)

[![Image from Gyazo](https://i.gyazo.com/791ff3007c3bf7f3df3301cd9917e150.png)](https://gyazo.com/791ff3007c3bf7f3df3301cd9917e150)

Closes #32 