### PR TITLE
Add:MatchInfoモデルのRspecテスト実装

### DIFF
--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,0 +1,8 @@
+example_id                              | status | run_time        |
+--------------------------------------- | ------ | --------------- |
+./spec/models/match_info_spec.rb[1:1:1] | passed | 0.00697 seconds |
+./spec/models/match_info_spec.rb[1:1:2] | passed | 0.0082 seconds  |
+./spec/models/match_info_spec.rb[1:1:3] | passed | 0.00742 seconds |
+./spec/models/match_info_spec.rb[1:1:4] | passed | 0.00662 seconds |
+./spec/models/match_info_spec.rb[1:1:5] | passed | 0.62577 seconds |
+./spec/models/match_info_spec.rb[1:1:6] | passed | 0.00708 seconds |

--- a/spec/factories/match_infos.rb
+++ b/spec/factories/match_infos.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :player do
+    player_name { "Test Player" }
+  end
+
+  factory :match_info do
+    association :user
+    association :player, factory: :player
+    association :opponent, factory: :player
+    match_date { Date.today }
+    match_name { "テストマッチ" }
+    memo { "テストメモ" }
+    player_name { "選手A" }
+    opponent_name { "選手B" }
+  end
+end

--- a/spec/models/match_info_spec.rb
+++ b/spec/models/match_info_spec.rb
@@ -1,0 +1,42 @@
+# spec/models/match_info_spec.rb
+require 'rails_helper'
+
+RSpec.describe MatchInfo, type: :model do
+  describe "バリデーション" do
+    it "有効な属性で有効になること" do
+      match_info = FactoryBot.build(:match_info)
+      expect(match_info).to be_valid
+    end
+
+    it "match_dateが無いと無効になること" do
+      match_info = FactoryBot.build(:match_info, match_date: nil)
+      expect(match_info).to be_invalid
+      expect(match_info.errors[:match_date]).to include("を入力してください")
+    end
+
+    it "match_nameが無いと無効になること" do
+      match_info = FactoryBot.build(:match_info, match_name: nil)
+      expect(match_info).to be_invalid
+      expect(match_info.errors[:match_name]).to include("を入力してください")
+    end
+
+    it "memoが500文字を超えると無効になること" do
+      long_memo = "a" * 501
+      match_info = FactoryBot.build(:match_info, memo: long_memo)
+      expect(match_info).to be_invalid
+      expect(match_info.errors[:memo]).to include(I18n.t('errors.messages.memo_too_long'))
+    end
+
+    it "player_nameが空だと無効になること" do
+      match_info = FactoryBot.build(:match_info, player_name: "")
+      expect(match_info).to be_invalid
+      expect(match_info.errors[:player_name]).to include(I18n.t('errors.messages.blank'))
+    end
+
+    it "opponent_nameが空だと無効になること" do
+      match_info = FactoryBot.build(:match_info, opponent_name: "")
+      expect(match_info).to be_invalid
+      expect(match_info.errors[:opponent_name]).to include(I18n.t('errors.messages.blank'))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -90,5 +89,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
## 概要
MatchInfoモデルについて下記のRSpecテストコードを実装しました。

1.バリデーションテスト
　モデルが受け入れるべき/拒否すべき入力を正しく制御しているか
2.#batting_score_data のユニットテスト
　Scoreデータの加工ロジックが期待通りか
3.#update_advice の例外処理の確認
　アドバイスの例外処理の分岐が正常に機能するか
4.アソシエーションの確認（shoulda-matchersのGemを導入）
　関連モデルとの関係性が正しく設定されていることを確認


## 確認方法
1. Gem を追加したので `bundle install` を実行してください
2. RAILS_ENV=test bundle exec rspec spec/modelsを実行してエラーが出ないか確認してください

## チェックリスト
- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした

Closes #65  
