### PR TITLE
feat: Sprint 4 — 途中中断・自動下書き保存・得点板移動・前のゲームへの戻り改善

### DIFF
--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -59,7 +59,7 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     @match_info.assign_attributes(match_info_params)
     @match_info.draft = true
     @match_info.partial_game_data = game_score_params.to_h
-    @match_info.save!
+    @match_info.save!(validate: false)
     redirect_to match_infos_path, notice: t('notices.match_info_interrupted')
   end
 
@@ -316,7 +316,7 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
 
   def match_info_params
     params.require(:match_info).permit(
-      :match_date, :match_name, :memo,
+      :match_date, :match_name, :memo, :match_format,
       scores_attributes: [:id, :batting_style, :score, :lost_score, :_destroy],
       games_attributes: [
         :id,

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -75,8 +75,8 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     @match_info = current_user.match_infos.find_by(id: params[:draft_id])
     return redirect_to new_match_info_path unless @match_info
 
-    delete_last_game(@match_info)
-    redirect_after_undo(@match_info)
+    restore_last_game_to_partial_data(@match_info)
+    redirect_to new_match_info_path(draft_id: @match_info.id)
   end
 
   def create # rubocop:disable Metrics/AbcSize
@@ -278,17 +278,22 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     redirect_to match_infos_path, alert: t('notices.match_info_not_found')
   end
 
-  def delete_last_game(match_info)
+  def restore_last_game_to_partial_data(match_info)
     last_game = match_info.games.order(:game_number).last
-    last_game&.destroy
+    return unless last_game
+
+    partial_data = reconstruct_partial_data(last_game)
+    last_game.destroy
+    match_info.partial_game_data = partial_data
+    match_info.save!(validate: false)
   end
 
-  def redirect_after_undo(match_info)
-    if match_info.games.empty?
-      match_info.destroy
-      redirect_to new_match_info_path
-    else
-      redirect_to new_match_info_path(draft_id: match_info.id)
+  def reconstruct_partial_data(game)
+    game.scores.each_with_object({}) do |score, hash|
+      hash[score.batting_style] = {
+        'score' => score.score,
+        'lost_score' => score.lost_score
+      }
     end
   end
 

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -49,7 +49,25 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     @match_info.save! unless @match_info.persisted?
     @match_info.save! if @match_info.changed?
     create_game_with_scores(@match_info)
-    @match_info.update(draft: true)
+    @match_info.update!(draft: true, partial_game_data: nil)
+    redirect_to new_match_info_path(draft_id: @match_info.id)
+  end
+
+  def interrupt
+    player, opponent = find_or_create_players
+    @match_info = draft_or_new_match_info(player, opponent)
+    @match_info.assign_attributes(match_info_params)
+    @match_info.draft = true
+    @match_info.partial_game_data = game_score_params.to_h
+    @match_info.save!
+    redirect_to match_infos_path, notice: t('notices.match_info_interrupted')
+  end
+
+  def restore_autosave
+    player = Player.find_or_create_by(player_name: params[:player_name].to_s)
+    opponent = Player.find_or_create_by(player_name: params[:opponent_name].to_s)
+    @match_info = build_autosave_match_info(player, opponent)
+    @match_info.save!(validate: false)
     redirect_to new_match_info_path(draft_id: @match_info.id)
   end
 
@@ -113,6 +131,7 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     @saved_games = []
     @current_game_number = 1
     @max_games = 5
+    @partial_scores = {}
   end
 
   def setup_draft_form(draft)
@@ -123,6 +142,7 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     @saved_games = draft.games.order(:game_number)
     @current_game_number = @saved_games.count + 1
     @max_games = draft.match_format
+    @partial_scores = draft.partial_game_data || {}
   end
 
   def draft_or_new_match_info(player, opponent) # rubocop:disable Metrics/AbcSize
@@ -270,6 +290,20 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     else
       redirect_to new_match_info_path(draft_id: match_info.id)
     end
+  end
+
+  def build_autosave_match_info(player, opponent)
+    match_info = current_user.match_infos.new(
+      match_date: params[:match_date],
+      match_name: params[:match_name],
+      memo: params[:memo],
+      match_format: params[:match_format] || 5,
+      player: player,
+      opponent: opponent,
+      draft: true
+    )
+    match_info.partial_game_data = JSON.parse(params[:game_scores] || '{}')
+    match_info
   end
 
   def basic_match_info_params

--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -1,0 +1,154 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    draftId: String,
+    page: String,
+    restoreAutosaveUrl: String
+  }
+
+  static targets = ["scoreField"]
+
+  connect() {
+    this.STORAGE_KEY = "tt_log_autosave"
+
+    if (this.pageValue === "index") {
+      this.checkAndShowBanner()
+    } else {
+      this.startAutoSave()
+      window.addEventListener("beforeunload", this._boundSaveState = this.saveState.bind(this))
+    }
+  }
+
+  disconnect() {
+    if (this.pageValue !== "index") {
+      this.stopAutoSave()
+      if (this._boundSaveState) {
+        window.removeEventListener("beforeunload", this._boundSaveState)
+      }
+    }
+  }
+
+  startAutoSave() {
+    this.autoSaveTimer = setInterval(() => this.saveState(), 30000)
+  }
+
+  stopAutoSave() {
+    if (this.autoSaveTimer) clearInterval(this.autoSaveTimer)
+  }
+
+  saveState() {
+    const data = this.collectFormData()
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(data))
+  }
+
+  clearStorage() {
+    localStorage.removeItem(this.STORAGE_KEY)
+  }
+
+  collectFormData() {
+    const form = this.element
+    const draftIdInput = form.querySelector('input[name="draft_id"]')
+    const matchDateInput = form.querySelector('input[name="match_info[match_date]"]')
+    const matchNameInput = form.querySelector('input[name="match_info[match_name]"]')
+    const playerNameInput = form.querySelector('input[name="match_info[player_name]"]')
+    const opponentNameInput = form.querySelector('input[name="match_info[opponent_name]"]')
+    const memoInput = form.querySelector('textarea[name="match_info[memo]"]')
+    const matchFormatInput = form.querySelector('select[name="match_info[match_format]"]')
+
+    const gameScores = {}
+    if (this.hasScoreFieldTarget) {
+      this.scoreFieldTargets.forEach((input) => {
+        const style = input.dataset.autoSaveStyleParam
+        const kind = input.dataset.autoSaveKindParam
+        if (style && kind) {
+          gameScores[style] = gameScores[style] || {}
+          gameScores[style][kind] = parseInt(input.value, 10) || 0
+        }
+      })
+    }
+
+    return {
+      draft_id: draftIdInput ? draftIdInput.value : this.draftIdValue,
+      match_date: matchDateInput ? matchDateInput.value : "",
+      match_name: matchNameInput ? matchNameInput.value : "",
+      player_name: playerNameInput ? playerNameInput.value : "",
+      opponent_name: opponentNameInput ? opponentNameInput.value : "",
+      memo: memoInput ? memoInput.value : "",
+      match_format: matchFormatInput ? matchFormatInput.value : "5",
+      game_scores: gameScores
+    }
+  }
+
+  checkAndShowBanner() {
+    const raw = localStorage.getItem(this.STORAGE_KEY)
+    if (!raw) return
+
+    try {
+      JSON.parse(raw)
+      const banner = document.getElementById("autosave-banner")
+      if (banner) banner.classList.remove("d-none")
+    } catch (_e) {
+      localStorage.removeItem(this.STORAGE_KEY)
+    }
+  }
+
+  restoreAutosave(event) {
+    event.preventDefault()
+    const raw = localStorage.getItem(this.STORAGE_KEY)
+    if (!raw) return
+
+    let data
+    try {
+      data = JSON.parse(raw)
+    } catch (_e) {
+      localStorage.removeItem(this.STORAGE_KEY)
+      return
+    }
+
+    if (data.draft_id) {
+      localStorage.removeItem(this.STORAGE_KEY)
+      window.location.href = `/match_infos/new?draft_id=${data.draft_id}`
+      return
+    }
+
+    const form = document.createElement("form")
+    form.method = "post"
+    form.action = this.restoreAutosaveUrlValue
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')
+    if (csrfToken) {
+      const csrfInput = document.createElement("input")
+      csrfInput.type = "hidden"
+      csrfInput.name = "authenticity_token"
+      csrfInput.value = csrfToken.getAttribute("content")
+      form.appendChild(csrfInput)
+    }
+
+    const fields = ["match_date", "match_name", "player_name", "opponent_name", "memo", "match_format"]
+    fields.forEach((field) => {
+      const input = document.createElement("input")
+      input.type = "hidden"
+      input.name = field
+      input.value = data[field] || ""
+      form.appendChild(input)
+    })
+
+    const gameScoresInput = document.createElement("input")
+    gameScoresInput.type = "hidden"
+    gameScoresInput.name = "game_scores"
+    gameScoresInput.value = JSON.stringify(data.game_scores || {})
+    form.appendChild(gameScoresInput)
+
+    localStorage.removeItem(this.STORAGE_KEY)
+    document.body.appendChild(form)
+    form.submit()
+  }
+
+  dismissBanner(event) {
+    event.preventDefault()
+    localStorage.removeItem(this.STORAGE_KEY)
+    const banner = document.getElementById("autosave-banner")
+    if (banner) banner.classList.add("d-none")
+  }
+}

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -17,7 +17,8 @@
 
 <div class="form-container fade-in-up">
   <%= form_with(model: match_info, url: match_infos_path, method: :post,
-      data: { controller: "scoreboard" }) do |form| %>
+      data: { controller: "scoreboard auto-save",
+              auto_save_draft_id_value: draft_id.to_s }) do |form| %>
 
     <%= hidden_field_tag :draft_id, draft_id if draft_id.present? %>
 
@@ -96,8 +97,10 @@
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"
                 class="plus">+</button>
-              <%= number_field_tag "game_scores[#{style}][score]", 0,
-                  class: "form-control small-input", min: 0 %>
+              <%= number_field_tag "game_scores[#{style}][score]",
+                  @partial_scores&.dig(style.to_s, 'score') || 0,
+                  class: "form-control small-input", min: 0,
+                  data: { auto_save_target: "scoreField", auto_save_style_param: style, auto_save_kind_param: "score" } %>
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepDown(); input.dispatchEvent(new Event('input', { bubbles: true }));"
                 class="minus">-</button>
@@ -110,8 +113,10 @@
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"
                 class="plus">+</button>
-              <%= number_field_tag "game_scores[#{style}][lost_score]", 0,
-                  class: "form-control small-input", min: 0 %>
+              <%= number_field_tag "game_scores[#{style}][lost_score]",
+                  @partial_scores&.dig(style.to_s, 'lost_score') || 0,
+                  class: "form-control small-input", min: 0,
+                  data: { auto_save_target: "scoreField", auto_save_style_param: style, auto_save_kind_param: "lost_score" } %>
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepDown(); input.dispatchEvent(new Event('input', { bubbles: true }));"
                 class="minus">-</button>
@@ -128,7 +133,8 @@
             class: "btn btn-secondary px-4 py-2 mt-4 me-2 rounded-pill shadow" %>
       <% end %>
       <%= form.submit "🚀 試合を分析する",
-          class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow" %>
+          class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow",
+          data: { action: "click->auto-save#clearStorage" } %>
     </div>
 
     <% if @draft_id.present? && @saved_games.any? %>
@@ -140,10 +146,11 @@
       </div>
     <% end %>
 
-    <% if @draft_id.present? %>
-      <div class="center-text mt-2">
-        <%= link_to "途中で中断する", match_infos_path, class: "btn btn-outline-secondary" %>
-      </div>
-    <% end %>
+    <div class="center-text mt-2">
+      <%= form.submit "途中で中断する",
+          formaction: interrupt_match_infos_path,
+          class: "btn btn-outline-secondary",
+          data: { action: "click->auto-save#clearStorage" } %>
+    </div>
   <% end %>
 </div>

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -139,9 +139,9 @@
 
     <% if @draft_id.present? && @saved_games.any? %>
       <div class="center-text mt-3">
-        <%= link_to "↩ 前のゲームを取り消す",
+        <%= link_to "↩ 前のゲームに戻る",
             undo_game_match_infos_path(draft_id: @draft_id),
-            data: { turbo_method: "delete", turbo_confirm: "直前のゲームの入力を取り消しますか？" },
+            data: { turbo_method: "delete" },
             class: "btn btn-outline-warning" %>
       </div>
     <% end %>

--- a/app/views/match_infos/_form_edit.html.erb
+++ b/app/views/match_infos/_form_edit.html.erb
@@ -40,10 +40,6 @@
 
     <% games = match_info.games.order(:game_number) %>
 
-    <%= render 'match_infos/scoreboard',
-               saved_games: games,
-               max_games: match_info.match_format || 5 %>
-
     <% batting_styles_order = %w[
       serve
       fore_drive back_drive
@@ -74,6 +70,10 @@
           編集したいゲームのタブを選択して、各技術の得点・失点数を修正してください。
         </div>
       </div>
+
+      <%= render 'match_infos/scoreboard',
+                 saved_games: games,
+                 max_games: match_info.match_format || 5 %>
 
       <ul class="nav nav-tabs mb-3" id="gameEditTabs" role="tablist">
         <% games.each_with_index do |game, idx| %>

--- a/app/views/match_infos/index.html.erb
+++ b/app/views/match_infos/index.html.erb
@@ -2,6 +2,17 @@
 
 <%= link_to "試合分析を開始", new_match_info_path, class: "btn btn-success btn-center-below-h1" %>
 
+<div data-controller="auto-save" data-auto-save-page-value="index"
+     data-auto-save-restore-autosave-url-value="<%= restore_autosave_match_infos_path %>">
+  <div id="autosave-banner" class="alert alert-info d-flex align-items-center justify-content-between d-none mt-3">
+    <span>自動保存データがあります。続きから入力できます。</span>
+    <div class="d-flex gap-2 align-items-center">
+      <a href="#" id="autosave-restore-link" data-action="click->auto-save#restoreAutosave" class="btn btn-sm btn-primary">続きから入力</a>
+      <button id="autosave-dismiss" type="button" data-action="click->auto-save#dismissBanner" class="btn-close" aria-label="閉じる"></button>
+    </div>
+  </div>
+</div>
+
 <%= search_form_for @q, html: { class: "row justify-content-center align-items-center" } do |f| %>
   <div class="col-10 col-md-3 mb-2">
     <label class="visually-hidden" for="match_name">大会名</label>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
     match_info_updated: "試合分析データが更新されました。"
     match_info_deleted: "試合分析データが削除されました。"
     match_info_not_found: "指定された投稿が見つかりません。"
+    match_info_interrupted: "分析を中断しました。下書きに保存されています。"
     password_reset_sent: "パスワードリセットのメールを送信しました"
     password_reset_success: "パスワードがリセットされました"
     invalid_login: "メールアドレスまたはパスワードが正しくありません。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
       get :autocomplete
       post :end_game
       delete :undo_game
+      post :interrupt
+      post :restore_autosave
     end
   end
 

--- a/db/migrate/20260421055529_add_partial_game_data_to_match_infos.rb
+++ b/db/migrate/20260421055529_add_partial_game_data_to_match_infos.rb
@@ -1,0 +1,5 @@
+class AddPartialGameDataToMatchInfos < ActiveRecord::Migration[7.1]
+  def change
+    add_column :match_infos, :partial_game_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_20_042008) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_21_055529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_20_042008) do
     t.text "advice"
     t.integer "match_format", default: 5
     t.boolean "draft", default: false, null: false
+    t.jsonb "partial_game_data"
     t.index ["opponent_id"], name: "index_match_infos_on_opponent_id"
     t.index ["player_id"], name: "index_match_infos_on_player_id"
     t.index ["user_id"], name: "index_match_infos_on_user_id"

--- a/plans/game-by-game-scoring-md-4-1-1-giggly-gizmo.md
+++ b/plans/game-by-game-scoring-md-4-1-1-giggly-gizmo.md
@@ -1,0 +1,184 @@
+# Sprint 4: 途中中断・自動下書き保存・得点板移動
+
+## Context
+
+ゲーム別スコアリング機能（Sprint 1〜3）の入力体験をさらに向上させるスプリント。現状の課題：
+- 「途中で中断する」ボタンが2ゲーム目以降にしか表示されず、1ゲーム目から中断できない
+- 中断時に入力中の技術別スコア（得点/失点数）が保存されないため、再開時に0からやり直しになる
+- 誤ってブラウザを閉じると入力データが全消え
+- 編集ページで得点板の位置がUIとして不自然
+
+## 実装対象 Features
+
+### F14: 1ゲーム目からの途中中断
+
+**現状**: 「途中で中断する」は `@draft_id.present?` 条件下でのみ表示（2ゲーム目以降）。
+
+**変更内容**:
+- `_form.html.erb` で「途中で中断する」を常時表示（条件削除）
+- リンクタグをフォーム POST ボタンに変更（`interrupt_match_infos_path` へ）
+- 新アクション `interrupt` を追加（詳細は後述）
+
+### F15: 途中中断時の技術スコア保存と復元
+
+**変更内容**:
+
+**DB Migration**: `match_infos` テーブルに `partial_game_data` JSON カラムを追加
+```ruby
+add_column :match_infos, :partial_game_data, :jsonb
+```
+
+**`interrupt` アクション**（新規）:
+```ruby
+def interrupt
+  find_or_create_players
+  @match_info = draft_or_new_match_info(@player, @opponent)
+  @match_info.assign_attributes(match_info_params)
+  @match_info.draft = true
+  @match_info.partial_game_data = game_score_params.to_h  # 入力中のゲームのスコアを保存
+  @match_info.save!
+  redirect_to match_infos_path, notice: "分析を中断しました。下書きに保存されています。"
+end
+```
+
+**`end_game` アクション修正**: `create_game_with_scores` 後に `partial_game_data` をクリア
+```ruby
+@match_info.update!(partial_game_data: nil)
+```
+
+**`setup_draft_form` 修正**: `partial_game_data` を `@partial_scores` としてビューに渡す
+```ruby
+@partial_scores = draft.partial_game_data || {}
+```
+
+**`_form.html.erb` 修正**: 各スコア入力フィールドの `value` を `@partial_scores` から復元
+```erb
+value="<%= @partial_scores.dig(batting_style.to_s, 'score') || 0 %>"
+value="<%= @partial_scores.dig(batting_style.to_s, 'lost_score') || 0 %>"
+```
+
+適用範囲: 1ゲーム目〜7ゲーム目すべて（フォームは共通テンプレートのため自動適用）
+
+**「途中で中断する」ボタン変更**（`_form.html.erb`）:
+- リンクタグ → フォーム POST ボタン（`interrupt_match_infos_path` へ）
+- フォームに hidden フィールドとして match_info メタデータ + draft_id + game_scores を含める
+
+### F16: 自動下書き保存（ブラウザを誤って閉じた場合）
+
+**方針**: localStorage + Stimulus コントローラーで実装。  
+定期保存（30秒間隔） + `beforeunload` イベントでブラウザ閉じ直前にも保存。
+
+**新規 Stimulus コントローラー**: `auto_save_controller.js`
+
+localStorage キー: `tt_log_autosave`  
+保存データ構造:
+```json
+{
+  "draft_id": 123,
+  "match_date": "2026-04-20",
+  "match_name": "大会名",
+  "player_name": "選手名",
+  "opponent_name": "相手名",
+  "memo": "メモ",
+  "match_format": 5,
+  "game_scores": {
+    "fore_drive": { "score": 4, "lost_score": 2 },
+    "back_drive": { "score": 1, "lost_score": 3 }
+  }
+}
+```
+
+**フォームページ（`_form.html.erb`）での動作**:
+- `connect()`: localStorage に保存データがあり、かつ `draft_id` が一致する場合、各スコア入力フィールドを復元
+- `saveState()`: 全フォームフィールドを収集して localStorage に保存
+- `beforeunload` イベントで `saveState()` を呼ぶ
+- 30秒ごとに `saveState()` を呼ぶ定期保存タイマー
+- 「途中で中断する」クリック時 or 「試合を分析する」送信時に localStorage をクリア
+
+**一覧ページ（`index.html.erb`）での動作**:
+- `connect()` 時に localStorage を確認
+- データがあれば「自動保存データが存在します」バナーを表示
+  - `draft_id` が存在: `new_match_info_path(draft_id: X)` へリンク
+  - `draft_id` なし: `restore_autosave_match_infos_path` へ POST（メタデータ + partial_scores を送信）
+- 「続きから入力」クリック後に localStorage をクリア
+
+**新規アクション `restore_autosave`**:
+```ruby
+def restore_autosave
+  # paramsからメタデータとgame_scoresを受け取り、draft MatchInfoを作成
+  find_or_create_players_from_params
+  @match_info = MatchInfo.new(match_info_base_params.merge(draft: true, user: current_user))
+  @match_info.partial_game_data = JSON.parse(params[:game_scores] || '{}')
+  @match_info.save!
+  redirect_to new_match_info_path(draft_id: @match_info.id)
+end
+```
+
+### F17: 編集ページの得点板位置変更
+
+**対象ファイル**: `app/views/match_infos/_form_edit.html.erb`
+
+**現在の順序** (38〜100行目付近):
+1. メタデータ（日付・大会名・選手名・メモ）
+2. **得点板** (43-45行目: `render 'match_infos/scoreboard'`)
+3. ゲーム別得点編集 見出し（71-76行目）
+4. ゲームタブ（78行目〜）
+
+**変更後の順序**:
+1. メタデータ
+2. ゲーム別得点編集 見出し
+3. **得点板** ← ここに移動
+4. ゲームタブ
+
+変更: `render 'match_infos/scoreboard'` の記述（43-45行目）を見出しブロック（71-76行目）の直後、タブ（78行目）の直前に移動する。
+
+## ルーティング変更
+
+```ruby
+# config/routes.rb
+resources :match_infos do
+  collection do
+    post :end_game
+    delete :undo_game
+    post :interrupt        # NEW
+    post :restore_autosave # NEW
+  end
+end
+```
+
+## 変更ファイル一覧
+
+| ファイル | 変更種別 | 内容 |
+|----------|---------|------|
+| `db/migrate/YYYYMMDD_add_partial_game_data_to_match_infos.rb` | 新規 | partial_game_data JSONBカラム追加 |
+| `config/routes.rb` | 修正 | interrupt, restore_autosave ルート追加 |
+| `app/controllers/match_infos_controller.rb` | 修正 | interrupt/restore_autosave アクション追加、end_game/setup_draft_form 修正 |
+| `app/views/match_infos/_form.html.erb` | 修正 | 途中中断ボタン変更、@partial_scores による初期値設定、auto_save data 属性追加 |
+| `app/views/match_infos/_form_edit.html.erb` | 修正 | 得点板の位置を変更（見出しとタブの間に移動） |
+| `app/views/match_infos/index.html.erb` | 修正 | 自動保存バナー追加、auto_save コントローラー接続 |
+| `app/javascript/controllers/auto_save_controller.js` | 新規 | localStorage 自動保存・復元ロジック |
+
+## 検証方法
+
+### F14/F15 検証
+1. 新規分析フォームを開く（1ゲーム目）
+2. フォアドライブの得点を4、失点を2に設定する
+3. 「途中で中断する」ボタンをクリック → 一覧ページへリダイレクトされること
+4. 一覧ページで対象の試合に「続きから入力」ボタンが表示されること
+5. 「続きから入力」をクリック → フォアドライブが得点4・失点2の状態で表示されること
+6. 2ゲーム目以降でも同様に動作すること（1〜7ゲーム全て）
+
+### F16 検証
+1. 分析フォームで2ゲーム目にデータを入力する（フォアドライブ: 得点5、バックドライブ: 失点3）
+2. ブラウザタブを強制的に閉じる（または `location.reload()` でシミュレート）
+3. 一覧ページを開く → 「自動保存データがあります」バナーが表示されること
+4. 「続きから入力」をクリック → 分析フォームが大会情報・技術別スコア込みで復元されること
+
+### F17 検証
+1. 既存の分析データの編集ページを開く
+2. 得点板が「ゲーム別得点編集」見出しとゲームタブの間に表示されること
+
+### RSpec / RuboCop
+```bash
+bundle exec rspec && bundle exec rubocop --parallel
+```

--- a/plans/sprint-4-generic-hollerith.md
+++ b/plans/sprint-4-generic-hollerith.md
@@ -1,0 +1,124 @@
+# Sprint 4 追加実装: 「前のゲームに戻る」機能
+
+## Context
+
+現在の「前のゲームを取り消す」ボタンは、直前ゲームの Game レコードおよび関連 Score レコードをすべて削除してから前のゲームフォームに戻る実装になっている。ユーザーはスコアを残したまま前のゲームを再編集したいため、削除せずにスコアを復元して戻る挙動に変更する。
+
+---
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/views/match_infos/_form.html.erb` | ボタンテキスト変更・確認ダイアログ削除 |
+| `app/controllers/match_infos_controller.rb` | `undo_game` アクション・関連 private メソッドの改修 |
+
+---
+
+## 実装方針
+
+### 1. ビュー変更（`_form.html.erb` 行140-147）
+
+- ボタンテキスト: `"↩ 前のゲームを取り消す"` → `"↩ 前のゲームに戻る"`
+- `turbo_confirm` を削除（確認ダイアログ不要）
+- ルート・HTTP メソッド（DELETE `undo_game_match_infos_path`）は変更しない
+
+```erb
+<% if @draft_id.present? && @saved_games.any? %>
+  <div class="center-text mt-3">
+    <%= link_to "↩ 前のゲームに戻る",
+        undo_game_match_infos_path(draft_id: @draft_id),
+        data: { turbo_method: "delete" },
+        class: "btn btn-outline-warning" %>
+  </div>
+<% end %>
+```
+
+### 2. コントローラー変更（`match_infos_controller.rb`）
+
+#### `undo_game` アクション（行74-80）を全面改修
+
+**現行:**
+```ruby
+def undo_game
+  @match_info = current_user.match_infos.find_by(id: params[:draft_id])
+  return redirect_to new_match_info_path unless @match_info
+
+  delete_last_game(@match_info)
+  redirect_after_undo(@match_info)
+end
+```
+
+**新実装:**
+```ruby
+def undo_game
+  @match_info = current_user.match_infos.find_by(id: params[:draft_id])
+  return redirect_to new_match_info_path unless @match_info
+
+  restore_last_game_to_partial_data(@match_info)
+  redirect_to new_match_info_path(draft_id: @match_info.id)
+end
+```
+
+#### 不要になる private メソッドを削除
+
+- `delete_last_game`（行281-284）: 削除
+- `redirect_after_undo`（行286-293）: 削除
+
+#### 新規 private メソッドを追加
+
+```ruby
+def restore_last_game_to_partial_data(match_info)
+  last_game = match_info.games.order(:game_number).last
+  return unless last_game
+
+  partial_data = reconstruct_partial_data(last_game)
+  last_game.destroy  # Game + Scores が cascade 削除される
+  match_info.update!(partial_game_data: partial_data)
+end
+
+def reconstruct_partial_data(game)
+  game.scores.each_with_object({}) do |score, hash|
+    hash[score.batting_style] = {
+      'score' => score.score,
+      'lost_score' => score.lost_score
+    }
+  end
+end
+```
+
+---
+
+## データフロー
+
+```
+「前のゲームに戻る」クリック
+↓ DELETE /match_infos/undo_game?draft_id=X
+↓ undo_game アクション
+  ├─ last_game = match_info.games.last（最後のゲーム取得）
+  ├─ partial_data = reconstruct_partial_data(last_game)
+  │   └─ game.scores → { "serve" => { "score" => 3, "lost_score" => 2 }, ... }
+  ├─ last_game.destroy（Game + Scores を cascade 削除）
+  └─ match_info.update!(partial_game_data: partial_data)
+↓ redirect_to new_match_info_path(draft_id: match_info.id)
+↓ setup_draft_form(@match_info)
+  └─ @partial_scores = match_info.partial_game_data
+     → フォームが前のゲームのスコアで復元表示される
+```
+
+### ゲーム1に戻る（saved_games が空になる）ケース
+
+`redirect_after_undo` を廃止したことで、ゲームが0件になっても `match_info` を削除せず `draft_id` を保持したままリダイレクトする。`setup_draft_form` で `@saved_games = []`、`@current_game_number = 1`、`@partial_scores` にスコアが復元され、ゲーム1の入力フォームがスコア付きで表示される。「前のゲームに戻る」ボタンは `@saved_games.any?` が false になるため非表示。
+
+---
+
+## 検証方法
+
+1. `bundle exec rspec && bundle exec rubocop --parallel` が全通過すること
+2. ブラウザで以下の操作を確認:
+   - ゲーム1を入力→終了→ゲーム2の画面に「↩ 前のゲームに戻る」が表示される
+   - ボタンをタップ→確認ダイアログなしで前のゲームに戻る
+   - ゲーム1のスコアがフォームに復元されている
+   - 復元されたスコアを修正して再度「Nゲーム目終了」を押せる
+   - 戻った後のゲーム2に再入力→正常に試合分析まで完了できる
+   - ゲーム2を終了→ゲーム3で「前のゲームに戻る」→ゲーム2スコアが復元される

--- a/spec/requests/match_infos_spec.rb
+++ b/spec/requests/match_infos_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe "MatchInfos", type: :request do
       let!(:draft) { create(:match_info, user: user, draft: true) }
       let!(:game) { create(:game, match_info: draft, game_number: 1, player_score: 11, opponent_score: 8) }
 
-      it "ゲームが削除されてMatchInfoも削除され新規フォームへリダイレクトする" do
+      it "ゲームのみ削除されてMatchInfoは残り draft のフォームへリダイレクトする" do
         expect do
           delete undo_game_match_infos_path, params: { draft_id: draft.id }
-        end.to change(Game, :count).by(-1).and change(MatchInfo, :count).by(-1)
-        expect(response).to redirect_to(new_match_info_path)
+        end.to change(Game, :count).by(-1).and change(MatchInfo, :count).by(0)
+        expect(response).to redirect_to(new_match_info_path(draft_id: draft.id))
       end
     end
 


### PR DESCRIPTION
## 概要

ゲーム別スコアリング機能（Sprint 1〜3）の入力体験を向上させる Sprint 4 の実装。

### F14: 1ゲーム目からの途中中断
- 「途中で中断する」ボタンを 1 ゲーム目から常時表示（`@draft_id.present?` 条件を削除）
- リンクタグをフォーム POST ボタンに変更（`interrupt_match_infos_path` へ送信）

### F15: 途中中断時の技術スコア保存と復元
- `match_infos` テーブルに `partial_game_data` JSONB カラムを追加
- `interrupt` アクション追加：入力中のゲームスコアを保存してから一覧へリダイレクト（バリデーションをスキップして必須項目が空でも保存可能）
- 再開時に `@partial_scores` からスコアフィールドを復元

### F16: 自動下書き保存
- `auto_save_controller.js` を新規作成：30 秒ごと + `beforeunload` で localStorage に保存
- 一覧ページに「自動保存データがあります」バナーを追加
- `restore_autosave` アクション追加：localStorage データからドラフトを復元

### F17: 編集ページの得点板位置変更
- `_form_edit.html.erb` で得点板をゲーム別得点編集見出しとゲームタブの間に移動

### 追加改善: 「前のゲームに戻る」でスコアを復元して再編集できるように変更
- ボタン名を「前のゲームを取り消す」→「前のゲームに戻る」に変更
- 確認ダイアログを削除（即座に戻れるように）
- 前のゲームのスコアをすべて削除していた挙動を、スコアを `partial_game_data` に復元してから戻る挙動に変更
- ゲーム1に戻る場合も MatchInfo を削除せず draft として保持し、スコア復元状態でフォームを表示

## 確認方法

1. `bundle exec rails db:migrate` を実行してください
2. 新規分析フォームで 1 ゲーム目から「途中で中断する」ボタンが表示されることを確認
3. スコアを入力して途中中断 → 一覧へリダイレクト後、「続きから入力」でスコアが復元されることを確認
4. フォームでデータ入力後に一覧ページへ移動すると自動保存バナーが表示されることを確認
5. 既存試合の編集ページで得点板が「ゲーム別得点編集」見出しとゲームタブの間に表示されることを確認
6. ゲーム1を入力して終了 → ゲーム2画面で「↩ 前のゲームに戻る」をタップ → ゲーム1のスコアが復元された状態でフォームが表示されることを確認

## 影響範囲

- `match_infos_controller.rb`: `interrupt` / `restore_autosave` アクション追加、`end_game` / `setup_draft_form` 修正、`undo_game` を削除からスコア復元に変更
- `_form.html.erb`: 「途中で中断する」ボタン変更、スコア初期値設定、auto_save コントローラー接続、「前のゲームに戻る」ボタン変更
- `index.html.erb`: 自動保存バナー追加
- `_form_edit.html.erb`: 得点板の位置変更

## チェックリスト

- [x] RuboCop をパスした
- [x] RSpec をパスした（52 examples, 0 failures）
- [x] Playwright による UI 動作確認を実施した

Closes #118 