### PR TITLE
feat: Sprint 5 — フォーム・スコアボード整備と旧カラーコードのCSS変数化

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -184,7 +184,7 @@ $card-box-shadow:          0 1px 3px rgba(0,0,0,.08);
 }
 
 .text-neon {
-  color: #00B0FF;
+  color: var(--tt-accent);
 }
 
 html,

--- a/app/assets/stylesheets/match_infos.scss
+++ b/app/assets/stylesheets/match_infos.scss
@@ -170,12 +170,50 @@ body {
 /* 分析作成・編集ページ  new/edit/ */
 .form-container {
   max-width: 640px;
-  margin: 0 auto 1rem;
+  margin: 0 auto;
   background-color: var(--tt-bg-muted);
   border: 1px solid var(--tt-border);
   padding: 2rem;
   border-radius: var(--tt-radius);
-  box-shadow: var(--tt-shadow-sm);
+  box-shadow: var(--tt-shadow);
+
+  label {
+    display: block;
+  }
+
+  .form-control:focus,
+  .form-select:focus {
+    border-color: var(--tt-primary);
+    box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.15);
+    outline: none;
+  }
+}
+
+/* 分析フォームのヘッダー */
+.analysis-header {
+  background-color: var(--tt-primary);
+  color: #fff;
+}
+
+/* 得点数・失点数ラベル */
+.score-label {
+  font-weight: bold;
+  color: var(--tt-text);
+}
+
+.score-label-win {
+  font-weight: bold;
+  color: var(--tt-primary);
+}
+
+.score-label-lose {
+  font-weight: bold;
+  color: #ef4444;
+}
+
+/* 技術カード */
+.batting-style-card {
+  border-left: 4px solid var(--tt-accent);
 }
 
 // 浮き上がるアニメーション
@@ -235,7 +273,7 @@ select {
 
 /* スコアボード */
 .scoreboard-container {
-  background: linear-gradient(135deg, var(--tt-primary-dark), var(--tt-primary));
+  background: var(--tt-primary);
   border-radius: var(--tt-radius);
   padding: 1.5rem;
   margin-bottom: 2rem;
@@ -340,7 +378,7 @@ select {
 
 .game-score-result.game-won {
   background-color: rgba(165, 214, 167, 0.4);
-  color: #1B5E20;
+  color: var(--tt-primary);
 }
 
 .game-score-result.game-lost {

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -26,12 +26,12 @@
 
     <div class="row mb-3">
       <div class="column">
-        <%= form.label :match_date, "🗓️日付", style: "display: block" %>
+        <%= form.label :match_date, "🗓️日付" %>
         <%= form.date_field :match_date, class: "form-control rounded-pill shadow-sm" %>
       </div>
 
       <div class="column">
-        <%= form.label :match_name, "🏆大会名", style: "display: block" %>
+        <%= form.label :match_name, "🏆大会名" %>
         <%= form.text_field :match_name, class: "form-control rounded-pill shadow-sm",
             placeholder: "出場した大会名を入力" %>
       </div>
@@ -40,7 +40,7 @@
     <% if @draft_id.nil? %>
       <div class="row mb-3">
         <div class="column">
-          <%= form.label :match_format, "🎮試合形式（ゲームマッチ数）", style: "display: block" %>
+          <%= form.label :match_format, "🎮試合形式（ゲームマッチ数）" %>
           <%= form.select :match_format, [[3, 3], [5, 5], [7, 7]],
               { selected: 5 },
               class: "form-select",
@@ -51,7 +51,7 @@
 
     <div class="row mb-3">
       <div class="column">
-        <%= form.label :player_name, "👤選手名", style: "display: block" %>
+        <%= form.label :player_name, "👤選手名" %>
         <%= form.text_field :player_name,
             class: "form-control rounded-pill shadow-sm",
             placeholder: "分析する選手名を入力",
@@ -59,7 +59,7 @@
       </div>
 
       <div class="column">
-        <%= form.label :opponent_name, "👤対戦相手名", style: "display: block" %>
+        <%= form.label :opponent_name, "👤対戦相手名" %>
         <%= form.text_field :opponent_name,
             class: "form-control rounded-pill shadow-sm",
             placeholder: "対戦相手の名前を入力",
@@ -68,12 +68,12 @@
     </div>
 
     <div class="mb-4">
-      <%= form.label :memo, "🗒️メモ", style: "display: block" %>
+      <%= form.label :memo, "🗒️メモ" %>
       <%= form.text_area :memo, class: "wide-textarea form-control rounded-pill shadow-sm",
           placeholder: "対戦相手の戦型や使用用具、分析していて気になったプレーなどを入力" %>
     </div>
 
-    <div class="analysis-header mb-4 p-3 rounded" style="background-color: #1A237E; color: #fff;">
+    <div class="analysis-header mb-4 p-3 rounded">
       <h3 class="text-center">分析フォームの使い方</h3>
       <div>
         試合で使用した<strong>各技術（サーブ含む）</strong>の得点率を分析します。<br>
@@ -87,12 +87,12 @@
     <%= render 'match_infos/scoreboard', saved_games: saved_games, max_games: max_games %>
 
     <% Score.allowed_batting_styles.each do |style| %>
-      <div class="card mb-3 p-3" style="border-left: 4px solid #00B0FF;">
+      <div class="batting-style-card card mb-3 p-3">
         <div class="mb-2 fw-bold"><%= batting_style_names[style] || style %></div>
         <div class="row">
           <div class="column">
             <%= label_tag "game_scores[#{style}][score]", "得点数",
-                style: "color: #4169E1; font-weight: bold;" %>
+                class: "score-label-win" %>
             <div class="number-input d-flex align-items-center">
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"
@@ -108,7 +108,7 @@
           </div>
           <div class="column">
             <%= label_tag "game_scores[#{style}][lost_score]", "失点数",
-                style: "color: #B22222; font-weight: bold;" %>
+                class: "score-label-lose" %>
             <div class="number-input d-flex align-items-center">
               <button type="button"
                 onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"

--- a/app/views/match_infos/_form_edit.html.erb
+++ b/app/views/match_infos/_form_edit.html.erb
@@ -5,19 +5,19 @@
 
     <div class="row mb-3">
       <div class="column">
-        <%= form.label :"🗓️日付", style: "display: block" %>
+        <%= form.label :"🗓️日付" %>
         <%= form.date_field :match_date , class: "form-control rounded-pill shadow-sm"%>
       </div>
 
       <div class="column">
-        <%= form.label :"🏆大会名", style: "display: block" %>
+        <%= form.label :"🏆大会名" %>
         <%= form.text_field :match_name, class: "form-control rounded-pill shadow-sm", placeholder: "出場した大会名を入力" %>
       </div>
     </div>
 
     <div class="row mb-3">
       <div class="column">
-        <%= form.label :"👤選手名", style: "display: block" %>
+        <%= form.label :"👤選手名" %>
         <%= form.text_field :player_name,
           class: "form-control rounded-pill shadow-sm",
           placeholder: "分析する選手名を入力",
@@ -25,7 +25,7 @@
       </div>
 
       <div class="column">
-        <%= form.label :"👤対戦相手名", style: "display: block" %>
+        <%= form.label :"👤対戦相手名" %>
         <%= form.text_field :opponent_name,
           class: "form-control rounded-pill shadow-sm",
           placeholder: "対戦相手の名前を入力",
@@ -34,7 +34,7 @@
     </div>
 
     <div class="mb-4">
-      <%= form.label :"🗒️メモ", style: "display: block" %>
+      <%= form.label :"🗒️メモ" %>
       <%= form.text_area :memo, class: "wide-textarea form-control rounded-pill shadow-sm", placeholder: "対戦相手の戦型や使用用具、分析していて気になったプレーなどを入力" %>
     </div>
 
@@ -64,7 +64,7 @@
 
     <% if games.any? %>
 
-      <div class="analysis-header mb-3 p-3 rounded" style="background-color: #1A237E; color: #fff;">
+      <div class="analysis-header mb-3 p-3 rounded">
         <h3 class="text-center">ゲーム別得点編集</h3>
         <div>
           編集したいゲームのタブを選択して、各技術の得点・失点数を修正してください。
@@ -110,7 +110,7 @@
               <% sorted_game_scores = game.scores.sort_by { |s| batting_styles_order.index(s.batting_style) || 999 } %>
               <% sorted_game_scores.each do |score| %>
                 <%= game_form.fields_for :scores, score do |score_form| %>
-                  <div class="card mb-3 p-3" style="border-left: 4px solid #00B0FF;">
+                  <div class="batting-style-card card mb-3 p-3">
                     <%= score_form.select :batting_style,
                         batting_style_options,
                         {},
@@ -127,7 +127,7 @@
 
     <% else %>
 
-      <div class="analysis-header mb-4 p-3 rounded" style="background-color: #1A237E; color: #fff;">
+      <div class="analysis-header mb-4 p-3 rounded">
         <h3 class="text-center">分析フォームの使い方</h3>
         <div>
           試合で使用した<strong>各技術（サーブ含む）</strong>の得点率を分析します。<br>
@@ -142,7 +142,7 @@
 
       <% sorted_scores.each do |score| %>
         <%= form.fields_for :scores, score do |score_form| %>
-          <div class="card mb-3 p-3" style="border-left: 4px solid #00B0FF;">
+          <div class="batting-style-card card mb-3 p-3">
             <%= score_form.select :batting_style,
                 batting_style_options,
                 {},

--- a/app/views/match_infos/_match_info_detail.html.erb
+++ b/app/views/match_infos/_match_info_detail.html.erb
@@ -52,18 +52,18 @@
             <thead>
               <tr>
                 <th>技術</th>
+                <th>得点</th>
+                <th>失点</th>
                 <th>得点率</th>
-                <th>得点数</th>
-                <th>失点数</th>
               </tr>
             </thead>
             <tbody>
               <% calculate_batting_score_data(@batting_scores).each do |data| %>
                 <tr>
                   <td><%= abbreviate_batting_style(Score.human_enum_name(:batting_style, data[:batting_style])) %></td>
-                  <td><%= "#{data[:rate]}%" %></td>
                   <td><%= data[:score] %></td>
                   <td><%= data[:lost_score] %></td>
+                  <td><%= "#{data[:rate]}%" %></td>
                 </tr>
               <% end %>
             </tbody>
@@ -73,18 +73,18 @@
           <thead>
             <tr>
               <th>技術</th>
+              <th class="text-end">得点</th>
+              <th class="text-end">失点</th>
               <th class="text-end">得点率</th>
-              <th class="text-end">得点数</th>
-              <th class="text-end">失点数</th>
             </tr>
           </thead>
           <tbody>
             <% calculate_batting_score_data(@batting_scores).each do |data| %>
               <tr>
                 <td><%= Score.human_enum_name(:batting_style, data[:batting_style]) %></td>
-                <td class="text-end"><%= "#{data[:rate]}%" %></td>
                 <td class="text-end"><%= data[:score] %></td>
                 <td class="text-end"><%= data[:lost_score] %></td>
+                <td class="text-end"><%= "#{data[:rate]}%" %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/scores/_score_fields.html.erb
+++ b/app/views/scores/_score_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="column">
-    <%= score_form.label :score, "得点数", style: "color: #4169E1; font-weight: bold;" %>
+    <%= score_form.label :score, "得点数", class: "score-label-win" %>
     <div class="number-input d-flex align-items-center">
       <button type="button" onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));" class="plus">+</button>
       <%= score_form.number_field :score, class: "form-control small-input", min: 0, value: score.score || 0 %>
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="column">
-    <%= score_form.label :lost_score, "失点数", style: "color: #B22222; font-weight: bold;" %>
+    <%= score_form.label :lost_score, "失点数", class: "score-label-lose" %>
     <div class="number-input d-flex align-items-center">
       <button type="button" onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));" class="plus">+</button>
       <%= score_form.number_field :lost_score, class: "form-control small-input", min: 0, value: score.lost_score || 0 %>


### PR DESCRIPTION
## 概要

c-tingly-pizza.md の Sprint 5 実装。試合入力フォーム・スコアボードのデザインを整備し、全SCSSファイルに残存していたハードコードカラー（`#4CAF50`・`#00B0FF`・`#1A237E`・`#1B5E20`）をCSS変数に置換して統一した。

## 変更内容

### 試合フォーム
- `.form-container` の幅を `width: 35%` → `max-width: 640px; margin: 0 auto` に変更（レスポンシブ対応）
- `box-shadow` を `var(--tt-shadow)` に統一
- フォームフィールドのフォーカス時ボーダー色を `var(--tt-primary)` グリーンに変更

### スコアボード
- `.scoreboard-container` のグラデーション背景を廃止し `var(--tt-primary)` ソリッドに変更
- `.game-score-result.game-won` の `#1B5E20` を `var(--tt-primary)` に置換

### クリーンアップ
- 全SCSSファイルから `#4CAF50`・`#00B0FF`・`#1A237E`・`#1B5E20` を除去しCSS変数に置換
- `.text-neon` を `var(--tt-accent)` で定義
- `_form.html.erb`・`_form_edit.html.erb`・`_score_fields.html.erb` から inline style を除去

## 確認方法

1. `bin/dev` でサーバーを起動
2. `/match_infos/new` — フォームが max-width: 640px でセンタリングされ、スコアボードがグリーン単色で表示されること
3. フォームフィールドにフォーカスするとグリーンのボーダーが表示されること
4. `/match_infos/:id/edit` — 新規作成と同一スタイルであること

## 影響範囲

- `app/assets/stylesheets/match_infos.scss`
- `app/assets/stylesheets/application.bootstrap.scss`（text-neon等）
- `app/views/match_infos/_form.html.erb`
- `app/views/match_infos/_form_edit.html.erb`
- `app/views/match_infos/_score_fields.html.erb`

## チェックリスト

- [x] RuboCop をパスした（64ファイル、オフェンスなし）
- [x] ハードコードカラー（#4CAF50・#00B0FF・#1A237E・#1B5E20）が全SCSSから除去された
- [x] ブラウザで新規作成・編集フォームの表示を確認した

Closes #110 