### PR TITLE
feat: Sprint 2 — ラリー入力UI（2ステップ入力）を実装

### DIFF
--- a/app/assets/stylesheets/match_infos.scss
+++ b/app/assets/stylesheets/match_infos.scss
@@ -605,6 +605,204 @@ select {
   vertical-align: middle;
 }
 
+/* ラリー入力UI */
+.rally-input-container {
+  margin-bottom: 1.5rem;
+}
+
+.rally-current-score {
+  font-size: 1.1rem;
+  font-weight: bold;
+  text-align: center;
+  padding: 0.5rem 1rem;
+  background: var(--tt-bg);
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  color: var(--tt-text);
+}
+
+.rally-score-label {
+  color: var(--tt-text-sub);
+  font-weight: normal;
+  margin-right: 0.25rem;
+}
+
+.rally-score-value {
+  color: var(--tt-primary);
+  font-size: 1.3rem;
+}
+
+.rally-step {
+  background: var(--tt-bg);
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.rally-step-title {
+  font-weight: bold;
+  color: var(--tt-text);
+  font-size: 0.95rem;
+}
+
+.rally-winner-buttons {
+  display: flex;
+  gap: 0.75rem;
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+  }
+}
+
+.rally-winner-btn {
+  flex: 1;
+  padding: 0.875rem 1rem;
+  font-size: 1rem;
+  font-weight: bold;
+  border-radius: var(--tt-radius);
+  border: 2px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.rally-winner-player {
+  background: var(--tt-primary-light);
+  color: var(--tt-primary);
+  border-color: var(--tt-primary);
+
+  &:hover {
+    background: var(--tt-primary);
+    color: #fff;
+  }
+}
+
+.rally-winner-opponent {
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #ef4444;
+
+  &:hover {
+    background: #ef4444;
+    color: #fff;
+  }
+}
+
+.rally-style-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.rally-style-btn {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.875rem;
+  border-radius: var(--tt-radius);
+  background: var(--tt-bg-muted);
+  border: 1px solid var(--tt-border);
+  color: var(--tt-text);
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: var(--tt-primary);
+    color: #fff;
+    border-color: var(--tt-primary);
+  }
+}
+
+.rally-show-more-btn {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.75rem;
+  background: transparent;
+  border: 1px solid var(--tt-border);
+  color: var(--tt-text-sub);
+  border-radius: var(--tt-radius);
+
+  &:hover {
+    background: var(--tt-bg-muted);
+    color: var(--tt-text);
+  }
+}
+
+.rally-cancel-btn {
+  font-size: 0.85rem;
+  padding: 0.3rem 0.75rem;
+  background: transparent;
+  border: 1px solid var(--tt-border);
+  color: var(--tt-text-sub);
+  border-radius: var(--tt-radius);
+
+  &:hover {
+    background: var(--tt-bg-muted);
+    color: var(--tt-text);
+  }
+}
+
+.rally-list-section {
+  border-top: 1px solid var(--tt-border);
+  padding-top: 0.75rem;
+}
+
+.rally-list-header {
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: var(--tt-text-sub);
+  margin-bottom: 0.5rem;
+}
+
+.rally-list-empty {
+  font-size: 0.875rem;
+  color: var(--tt-text-sub);
+  text-align: center;
+  padding: 0.75rem;
+}
+
+.rally-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.rally-item-player {
+  background: var(--tt-primary-light);
+  border-left: 3px solid var(--tt-primary);
+}
+
+.rally-item-opponent {
+  background: #fee2e2;
+  border-left: 3px solid #ef4444;
+}
+
+.rally-item-seq {
+  color: var(--tt-text-sub);
+  font-size: 0.8rem;
+  min-width: 3.5rem;
+}
+
+.rally-item-detail {
+  flex: 1;
+  color: var(--tt-text);
+  font-weight: 500;
+}
+
+.rally-undo-btn {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--tt-border);
+  color: var(--tt-text-sub);
+  border-radius: 4px;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--tt-bg-muted);
+    color: var(--tt-text);
+  }
+}
+
 /* 画面が小さい場合に縦並びに変更する */
 @media (max-width: 900px) {
   .row {

--- a/app/assets/stylesheets/match_infos.scss
+++ b/app/assets/stylesheets/match_infos.scss
@@ -610,6 +610,71 @@ select {
   margin-bottom: 1.5rem;
 }
 
+.rally-server-select-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.25rem 1rem;
+  margin-bottom: 0.75rem;
+  background: var(--tt-bg);
+  border: 1px solid var(--tt-border);
+  border-radius: var(--tt-radius);
+}
+
+.rally-server-select-title {
+  font-weight: bold;
+  font-size: 1.05rem;
+  color: var(--tt-text);
+  text-align: center;
+}
+
+.rally-server-buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    width: 100%;
+  }
+}
+
+.rally-server-btn {
+  min-width: 140px;
+  padding: 0.875rem 1.25rem;
+  font-size: 1rem;
+  font-weight: bold;
+  border-radius: var(--tt-radius);
+  border: 2px solid transparent;
+  transition: all 0.15s ease;
+
+  @media (max-width: 600px) {
+    width: 100%;
+  }
+}
+
+.rally-server-player {
+  background: var(--tt-primary-light);
+  color: var(--tt-primary);
+  border-color: var(--tt-primary);
+
+  &:hover {
+    background: var(--tt-primary);
+    color: #fff;
+  }
+}
+
+.rally-server-opponent {
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #ef4444;
+
+  &:hover {
+    background: #ef4444;
+    color: #fff;
+  }
+}
+
 .rally-current-score {
   font-size: 1.1rem;
   font-weight: bold;

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -179,6 +179,21 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
       @saved_games = []
       @current_game_number = 1
     end
+    restore_rally_params_to_partial_scores
+  end
+
+  def restore_rally_params_to_partial_scores
+    return if params[:rallies].blank?
+
+    rallies = JSON.parse(params[:rallies])
+    return unless rallies.is_a?(Array) && rallies.any?
+
+    @partial_scores = {
+      'rallies' => rallies,
+      'first_server' => params[:first_server].presence
+    }
+  rescue JSON::ParserError
+    nil
   end
 
   def create_game_with_scores(match_info)

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -304,7 +304,7 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
       rally_data = game.rallies.order(:sequence_number).map do |r|
         { 'winner' => r.winner, 'batting_style' => r.batting_style }
       end
-      { 'rallies' => rally_data }
+      { 'rallies' => rally_data, 'first_server' => game.first_server }
     else
       reconstruct_partial_data(game)
     end
@@ -321,8 +321,10 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     game_number = match_info.games.count + 1
     player_total = rallies_data.count { |r| r['winner'] == 'player' }
     opponent_total = rallies_data.count { |r| r['winner'] == 'opponent' }
+    first_server = params[:first_server].presence
     match_info.games.create!(
-      game_number: game_number, player_score: player_total, opponent_score: opponent_total
+      game_number: game_number, player_score: player_total, opponent_score: opponent_total,
+      first_server: first_server
     )
   end
 

--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     restoreAutosaveUrl: String
   }
 
-  static targets = ["scoreField"]
+  static targets = ["scoreField", "rallyField"]
 
   connect() {
     this.STORAGE_KEY = "tt_log_autosave"
@@ -56,17 +56,7 @@ export default class extends Controller {
     const memoInput = form.querySelector('textarea[name="match_info[memo]"]')
     const matchFormatInput = form.querySelector('select[name="match_info[match_format]"]')
 
-    const gameScores = {}
-    if (this.hasScoreFieldTarget) {
-      this.scoreFieldTargets.forEach((input) => {
-        const style = input.dataset.autoSaveStyleParam
-        const kind = input.dataset.autoSaveKindParam
-        if (style && kind) {
-          gameScores[style] = gameScores[style] || {}
-          gameScores[style][kind] = parseInt(input.value, 10) || 0
-        }
-      })
-    }
+    const rallies = this._collectRallies()
 
     return {
       draft_id: draftIdInput ? draftIdInput.value : this.draftIdValue,
@@ -76,8 +66,20 @@ export default class extends Controller {
       opponent_name: opponentNameInput ? opponentNameInput.value : "",
       memo: memoInput ? memoInput.value : "",
       match_format: matchFormatInput ? matchFormatInput.value : "5",
-      game_scores: gameScores
+      rallies: rallies
     }
+  }
+
+  _collectRallies() {
+    const serializedInput = this.element.querySelector('input[name="rallies"]')
+    if (serializedInput && serializedInput.value) {
+      try {
+        return JSON.parse(serializedInput.value)
+      } catch (_e) {
+        // ignore
+      }
+    }
+    return []
   }
 
   checkAndShowBanner() {
@@ -134,11 +136,11 @@ export default class extends Controller {
       form.appendChild(input)
     })
 
-    const gameScoresInput = document.createElement("input")
-    gameScoresInput.type = "hidden"
-    gameScoresInput.name = "game_scores"
-    gameScoresInput.value = JSON.stringify(data.game_scores || {})
-    form.appendChild(gameScoresInput)
+    const ralliesInput = document.createElement("input")
+    ralliesInput.type = "hidden"
+    ralliesInput.name = "rallies_autosave"
+    ralliesInput.value = JSON.stringify(data.rallies || [])
+    form.appendChild(ralliesInput)
 
     localStorage.removeItem(this.STORAGE_KEY)
     document.body.appendChild(form)

--- a/app/javascript/controllers/rally_input_controller.js
+++ b/app/javascript/controllers/rally_input_controller.js
@@ -70,6 +70,7 @@ export default class extends Controller {
     this.updateEndGameButton()
     this.serializeRallies()
     this.updateServerUI()
+    if (this.rallies.length > 0) this.dispatchScoreUpdated()
 
     this.element.addEventListener("rally:getRallies", (e) => {
       e.detail.rallies = [...this.rallies]

--- a/app/javascript/controllers/rally_input_controller.js
+++ b/app/javascript/controllers/rally_input_controller.js
@@ -35,17 +35,19 @@ export default class extends Controller {
   static targets = [
     "step1", "step2", "styleButtons", "rallyList",
     "endGameBtn", "serialized", "currentScore",
-    "showMore"
+    "showMore", "serverSelect", "serverIndicator", "firstServerField"
   ]
 
   static values = {
-    initialRallies: String
+    initialRallies: String,
+    initialFirstServer: String
   }
 
   connect() {
     this.rallies = []
     this.selectedWinner = null
     this.showingAll = false
+    this.firstServer = null
 
     if (this.hasInitialRalliesValue && this.initialRalliesValue) {
       try {
@@ -58,15 +60,26 @@ export default class extends Controller {
       }
     }
 
+    if (this.hasInitialFirstServerValue && this.initialFirstServerValue) {
+      this.firstServer = this.initialFirstServerValue
+    }
+
     this.renderStyleButtons()
     this.renderRallyList()
     this.updateScore()
     this.updateEndGameButton()
     this.serializeRallies()
+    this.updateServerUI()
 
     this.element.addEventListener("rally:getRallies", (e) => {
       e.detail.rallies = [...this.rallies]
     })
+  }
+
+  selectServer(event) {
+    this.firstServer = event.currentTarget.dataset.server
+    this.updateServerUI()
+    this.serializeRallies()
   }
 
   selectWinner(event) {
@@ -115,6 +128,38 @@ export default class extends Controller {
     }
   }
 
+  getCurrentServer() {
+    if (!this.firstServer) return null
+    const total = this.rallies.length
+    let isFirstServerTurn
+    if (total < 20) {
+      isFirstServerTurn = Math.floor(total / 2) % 2 === 0
+    } else {
+      isFirstServerTurn = total % 2 === 0
+    }
+    return isFirstServerTurn ? this.firstServer : (this.firstServer === 'player' ? 'opponent' : 'player')
+  }
+
+  getServerLabel() {
+    const current = this.getCurrentServer()
+    if (!current) return ''
+    return current === 'player' ? '🏓 自分のサーブ中' : '🏓 相手のサーブ中'
+  }
+
+  updateServerUI() {
+    const hasServer = !!this.firstServer
+    if (this.hasServerSelectTarget) {
+      this.serverSelectTarget.classList.toggle('d-none', hasServer)
+    }
+    if (this.hasServerIndicatorTarget) {
+      this.serverIndicatorTarget.classList.toggle('d-none', !hasServer)
+      this.serverIndicatorTarget.textContent = this.getServerLabel()
+    }
+    if (this.hasStep1Target) {
+      this.step1Target.classList.toggle('d-none', !hasServer)
+    }
+  }
+
   renderStyleButtons() {
     if (!this.hasStyleButtonsTarget) return
     const styles = this.showingAll ? BATTING_STYLES_ALL : BATTING_STYLES_PRIMARY
@@ -156,10 +201,16 @@ export default class extends Controller {
     if (this.hasCurrentScoreTarget) {
       this.currentScoreTarget.textContent = `${playerScore} - ${opponentScore}`
     }
+
+    this.updateServerUI()
   }
 
   updateEndGameButton() {
     if (!this.hasEndGameBtnTarget) return
+    if (!this.firstServer) {
+      this.endGameBtnTarget.disabled = true
+      return
+    }
     const playerScore = this.rallies.filter(r => r.winner === 'player').length
     const opponentScore = this.rallies.filter(r => r.winner === 'opponent').length
     const canEnd = Math.max(playerScore, opponentScore) >= 11 &&
@@ -170,6 +221,9 @@ export default class extends Controller {
   serializeRallies() {
     if (this.hasSerializedTarget) {
       this.serializedTarget.value = JSON.stringify(this.rallies)
+    }
+    if (this.hasFirstServerFieldTarget) {
+      this.firstServerFieldTarget.value = this.firstServer || ''
     }
   }
 

--- a/app/javascript/controllers/rally_input_controller.js
+++ b/app/javascript/controllers/rally_input_controller.js
@@ -1,0 +1,184 @@
+import { Controller } from "@hotwired/stimulus"
+
+const BATTING_STYLE_NAMES = {
+  serve: 'サーブ',
+  receive: 'レシーブ',
+  fore_drive_vs_topspin: '対上回転フォアドライブ',
+  back_drive_vs_topspin: '対上回転バックドライブ',
+  fore_drive_vs_backspin: '対下回転フォアドライブ',
+  back_drive_vs_backspin: '対下回転バックドライブ',
+  fore_push: 'フォアツッツキ',
+  back_push: 'バックツッツキ',
+  fore_stop: 'フォアストップ',
+  back_stop: 'バックストップ',
+  fore_flick: 'フォアフリック',
+  back_flick: 'バックフリック',
+  chiquita: 'チキータ',
+  fore_block: 'フォアブロック',
+  back_block: 'バックブロック',
+  fore_counter: 'フォアカウンター',
+  back_counter: 'バックカウンター',
+  fore_smash: 'フォアスマッシュ',
+  back_smash: 'バックスマッシュ',
+  net_or_edge: 'ネットorエッジ'
+}
+
+const BATTING_STYLES_PRIMARY = [
+  'serve', 'fore_drive_vs_topspin', 'back_drive_vs_topspin',
+  'fore_drive_vs_backspin', 'back_drive_vs_backspin',
+  'fore_push', 'back_push', 'chiquita'
+]
+
+const BATTING_STYLES_ALL = Object.keys(BATTING_STYLE_NAMES).filter(s => s !== 'receive')
+
+export default class extends Controller {
+  static targets = [
+    "step1", "step2", "styleButtons", "rallyList",
+    "endGameBtn", "serialized", "currentScore",
+    "showMore"
+  ]
+
+  static values = {
+    initialRallies: String
+  }
+
+  connect() {
+    this.rallies = []
+    this.selectedWinner = null
+    this.showingAll = false
+
+    if (this.hasInitialRalliesValue && this.initialRalliesValue) {
+      try {
+        const initial = JSON.parse(this.initialRalliesValue)
+        if (Array.isArray(initial)) {
+          this.rallies = initial
+        }
+      } catch (_e) {
+        // ignore parse errors
+      }
+    }
+
+    this.renderStyleButtons()
+    this.renderRallyList()
+    this.updateScore()
+    this.updateEndGameButton()
+    this.serializeRallies()
+
+    this.element.addEventListener("rally:getRallies", (e) => {
+      e.detail.rallies = [...this.rallies]
+    })
+  }
+
+  selectWinner(event) {
+    this.selectedWinner = event.currentTarget.dataset.winner
+    if (this.hasStep1Target) this.step1Target.classList.add("d-none")
+    if (this.hasStep2Target) this.step2Target.classList.remove("d-none")
+  }
+
+  selectStyle(event) {
+    const battingStyle = event.currentTarget.dataset.style
+    if (!this.selectedWinner || !battingStyle) return
+
+    this.rallies.push({ winner: this.selectedWinner, batting_style: battingStyle })
+    this.selectedWinner = null
+
+    if (this.hasStep2Target) this.step2Target.classList.add("d-none")
+    if (this.hasStep1Target) this.step1Target.classList.remove("d-none")
+
+    this.renderRallyList()
+    this.updateScore()
+    this.updateEndGameButton()
+    this.serializeRallies()
+    this.dispatchScoreUpdated()
+  }
+
+  undo() {
+    if (this.rallies.length === 0) return
+    this.rallies.pop()
+
+    this.selectedWinner = null
+    if (this.hasStep2Target) this.step2Target.classList.add("d-none")
+    if (this.hasStep1Target) this.step1Target.classList.remove("d-none")
+
+    this.renderRallyList()
+    this.updateScore()
+    this.updateEndGameButton()
+    this.serializeRallies()
+    this.dispatchScoreUpdated()
+  }
+
+  toggleShowMore() {
+    this.showingAll = !this.showingAll
+    this.renderStyleButtons()
+    if (this.hasShowMoreTarget) {
+      this.showMoreTarget.textContent = this.showingAll ? '閉じる ▲' : 'もっと見る ▼'
+    }
+  }
+
+  renderStyleButtons() {
+    if (!this.hasStyleButtonsTarget) return
+    const styles = this.showingAll ? BATTING_STYLES_ALL : BATTING_STYLES_PRIMARY
+    this.styleButtonsTarget.innerHTML = styles.map(style => {
+      const name = BATTING_STYLE_NAMES[style] || style
+      return `<button type="button" class="btn rally-style-btn"
+        data-action="click->rally-input#selectStyle"
+        data-style="${style}">${name}</button>`
+    }).join('')
+  }
+
+  renderRallyList() {
+    if (!this.hasRallyListTarget) return
+    if (this.rallies.length === 0) {
+      this.rallyListTarget.innerHTML = '<div class="rally-list-empty">まだラリーが入力されていません</div>'
+      return
+    }
+
+    const items = [...this.rallies].reverse().map((rally, revIdx) => {
+      const idx = this.rallies.length - revIdx
+      const winnerLabel = rally.winner === 'player' ? '自分' : '相手'
+      const winnerClass = rally.winner === 'player' ? 'rally-item-player' : 'rally-item-opponent'
+      const styleName = BATTING_STYLE_NAMES[rally.batting_style] || rally.batting_style
+      const isFirst = revIdx === 0
+      return `<div class="rally-item ${winnerClass}">
+        <span class="rally-item-seq">${idx}本目</span>
+        <span class="rally-item-detail">${winnerLabel} ← ${styleName}</span>
+        ${isFirst ? '<button type="button" class="btn btn-sm rally-undo-btn" data-action="click->rally-input#undo">↩ 取り消し</button>' : ''}
+      </div>`
+    }).join('')
+
+    this.rallyListTarget.innerHTML = items
+  }
+
+  updateScore() {
+    const playerScore = this.rallies.filter(r => r.winner === 'player').length
+    const opponentScore = this.rallies.filter(r => r.winner === 'opponent').length
+
+    if (this.hasCurrentScoreTarget) {
+      this.currentScoreTarget.textContent = `${playerScore} - ${opponentScore}`
+    }
+  }
+
+  updateEndGameButton() {
+    if (!this.hasEndGameBtnTarget) return
+    const playerScore = this.rallies.filter(r => r.winner === 'player').length
+    const opponentScore = this.rallies.filter(r => r.winner === 'opponent').length
+    const canEnd = Math.max(playerScore, opponentScore) >= 11 &&
+                   Math.abs(playerScore - opponentScore) >= 2
+    this.endGameBtnTarget.disabled = !canEnd
+  }
+
+  serializeRallies() {
+    if (this.hasSerializedTarget) {
+      this.serializedTarget.value = JSON.stringify(this.rallies)
+    }
+  }
+
+  dispatchScoreUpdated() {
+    const playerScore = this.rallies.filter(r => r.winner === 'player').length
+    const opponentScore = this.rallies.filter(r => r.winner === 'opponent').length
+    this.element.dispatchEvent(new CustomEvent('rally:scoreUpdated', {
+      bubbles: true,
+      detail: { playerScore, opponentScore }
+    }))
+  }
+}

--- a/app/javascript/controllers/scoreboard_controller.js
+++ b/app/javascript/controllers/scoreboard_controller.js
@@ -29,11 +29,27 @@ export default class extends Controller {
       tab.addEventListener('shown.bs.tab', (event) => this.onGameTabShown(event))
     })
 
+    this._boundRallyScoreUpdated = this.onRallyScoreUpdated.bind(this)
+    this.element.addEventListener('rally:scoreUpdated', this._boundRallyScoreUpdated)
+
     this.update()
+  }
+
+  disconnect() {
+    if (this._boundRallyScoreUpdated) {
+      this.element.removeEventListener('rally:scoreUpdated', this._boundRallyScoreUpdated)
+    }
   }
 
   onGameTabShown(event) {
     this.updateFromActivePanel()
+  }
+
+  onRallyScoreUpdated(event) {
+    const { playerScore, opponentScore } = event.detail || {}
+    if (playerScore === undefined) return
+    if (this.hasPlayerPointsTarget) this.playerPointsTarget.textContent = playerScore
+    if (this.hasOpponentPointsTarget) this.opponentPointsTarget.textContent = opponentScore
   }
 
   updateNames() {

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,6 +4,8 @@ class Game < ApplicationRecord
   belongs_to :match_info
   accepts_nested_attributes_for :scores
 
+  enum :first_server, { player: 0, opponent: 1 }
+
   def recalculate_scores
     update(
       player_score: scores.sum(:score),

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -1,30 +1,10 @@
-<% batting_style_names = {
-  'serve'                  => 'サーブ',
-  'receive'                => 'レシーブ',
-  'fore_drive_vs_topspin'  => '対上回転フォアドライブ',
-  'back_drive_vs_topspin'  => '対上回転バックドライブ',
-  'fore_drive_vs_backspin' => '対下回転フォアドライブ',
-  'back_drive_vs_backspin' => '対下回転バックドライブ',
-  'fore_push'              => 'フォアツッツキ',
-  'back_push'              => 'バックツッツキ',
-  'fore_stop'              => 'フォアストップ',
-  'back_stop'              => 'バックストップ',
-  'fore_flick'             => 'フォアフリック',
-  'back_flick'             => 'バックフリック',
-  'chiquita'               => 'チキータ',
-  'fore_block'             => 'フォアブロック',
-  'back_block'             => 'バックブロック',
-  'fore_counter'           => 'フォアカウンター',
-  'back_counter'           => 'バックカウンター',
-  'fore_smash'             => 'フォアスマッシュ',
-  'back_smash'             => 'バックスマッシュ',
-  'net_or_edge'            => 'ネットorエッジ'
-} %>
 
 <div class="form-container fade-in-up">
+  <% initial_rallies_json = (@partial_scores&.dig('rallies') || []).to_json %>
   <%= form_with(model: match_info, url: match_infos_path, method: :post,
-      data: { controller: "scoreboard auto-save",
-              auto_save_draft_id_value: draft_id.to_s }) do |form| %>
+      data: { controller: "scoreboard auto-save rally-input",
+              auto_save_draft_id_value: draft_id.to_s,
+              rally_input_initial_rallies_value: initial_rallies_json }) do |form| %>
 
     <%= hidden_field_tag :draft_id, draft_id if draft_id.present? %>
 
@@ -80,61 +60,26 @@
     </div>
 
     <div class="analysis-header mb-4 p-3 rounded">
-      <h3 class="text-center">分析フォームの使い方</h3>
+      <h3 class="text-center">ラリー入力</h3>
       <div>
-        試合で使用した<strong>各技術の得点率</strong>を分析します。<br>
-        得点したらその技術の「得点数」に、失点したら「失点数」に1ずつ加算してください。<br>
-        例：サービスエース → サーブの得点数 ＋1 ／ サービスミス → サーブの失点数 ＋1
+        1本ずつ順番に「誰が得点したか」「どの技術で決めたか」を入力してください。<br>
+        入力したラリーデータから技術別の得点率を自動集計します。
       </div>
     </div>
 
     <%= render 'match_infos/scoreboard', saved_games: saved_games, max_games: max_games %>
 
-    <% Score.allowed_batting_styles.each do |style| %>
-      <div class="batting-style-card card mb-3 p-3">
-        <div class="mb-2 fw-bold"><%= batting_style_names[style] || style %></div>
-        <div class="row">
-          <div class="column">
-            <%= label_tag "game_scores[#{style}][score]", "得点数",
-                class: "score-label-win" %>
-            <div class="number-input d-flex align-items-center">
-              <button type="button"
-                onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"
-                class="plus">+</button>
-              <%= number_field_tag "game_scores[#{style}][score]",
-                  @partial_scores&.dig(style.to_s, 'score') || 0,
-                  class: "form-control small-input", min: 0,
-                  data: { auto_save_target: "scoreField", auto_save_style_param: style, auto_save_kind_param: "score" } %>
-              <button type="button"
-                onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepDown(); input.dispatchEvent(new Event('input', { bubbles: true }));"
-                class="minus">-</button>
-            </div>
-          </div>
-          <div class="column">
-            <%= label_tag "game_scores[#{style}][lost_score]", "失点数",
-                class: "score-label-lose" %>
-            <div class="number-input d-flex align-items-center">
-              <button type="button"
-                onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepUp(); input.dispatchEvent(new Event('input', { bubbles: true }));"
-                class="plus">+</button>
-              <%= number_field_tag "game_scores[#{style}][lost_score]",
-                  @partial_scores&.dig(style.to_s, 'lost_score') || 0,
-                  class: "form-control small-input", min: 0,
-                  data: { auto_save_target: "scoreField", auto_save_style_param: style, auto_save_kind_param: "lost_score" } %>
-              <button type="button"
-                onclick="const input = this.parentNode.querySelector('input[type=number]'); input.stepDown(); input.dispatchEvent(new Event('input', { bubbles: true }));"
-                class="minus">-</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    <% end %>
+    <%= render 'match_infos/rally_input' %>
+
+    <input type="hidden" name="rallies" data-rally-input-target="serialized"
+           value="<%= initial_rallies_json %>">
 
     <div class="center-text">
       <% if current_game_number <= max_games %>
         <%= form.submit "#{current_game_number}ゲーム目終了",
             formaction: end_game_match_infos_path,
-            class: "btn btn-secondary px-4 py-2 mt-4 me-2 rounded-pill shadow" %>
+            class: "btn btn-secondary px-4 py-2 mt-4 me-2 rounded-pill shadow",
+            data: { rally_input_target: "endGameBtn" } %>
       <% end %>
       <%= form.submit "🚀 試合を分析する",
           class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow",

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -1,10 +1,19 @@
 
 <div class="form-container fade-in-up">
   <% initial_rallies_json = (@partial_scores&.dig('rallies') || []).to_json %>
+  <%
+    last_game = @saved_games.last
+    initial_first_server = if last_game&.first_server
+                              last_game.first_server == 'player' ? 'opponent' : 'player'
+                            else
+                              nil
+                            end
+  %>
   <%= form_with(model: match_info, url: match_infos_path, method: :post,
       data: { controller: "scoreboard auto-save rally-input",
               auto_save_draft_id_value: draft_id.to_s,
-              rally_input_initial_rallies_value: initial_rallies_json }) do |form| %>
+              rally_input_initial_rallies_value: initial_rallies_json,
+              rally_input_initial_first_server_value: initial_first_server.to_s }) do |form| %>
 
     <%= hidden_field_tag :draft_id, draft_id if draft_id.present? %>
 
@@ -69,7 +78,7 @@
 
     <%= render 'match_infos/scoreboard', saved_games: saved_games, max_games: max_games %>
 
-    <%= render 'match_infos/rally_input' %>
+    <%= render 'match_infos/rally_input', initial_first_server: initial_first_server %>
 
     <input type="hidden" name="rallies" data-rally-input-target="serialized"
            value="<%= initial_rallies_json %>">

--- a/app/views/match_infos/_form.html.erb
+++ b/app/views/match_infos/_form.html.erb
@@ -3,11 +3,10 @@
   <% initial_rallies_json = (@partial_scores&.dig('rallies') || []).to_json %>
   <%
     last_game = @saved_games.last
-    initial_first_server = if last_game&.first_server
-                              last_game.first_server == 'player' ? 'opponent' : 'player'
-                            else
-                              nil
-                            end
+    initial_first_server = @partial_scores&.dig('first_server') ||
+                           if last_game&.first_server
+                             last_game.first_server == 'player' ? 'opponent' : 'player'
+                           end
   %>
   <%= form_with(model: match_info, url: match_infos_path, method: :post,
       data: { controller: "scoreboard auto-save rally-input",

--- a/app/views/match_infos/_rally_input.html.erb
+++ b/app/views/match_infos/_rally_input.html.erb
@@ -1,0 +1,58 @@
+<% initial_rallies = local_assigns[:initial_rallies] %>
+
+<div class="rally-input-container">
+
+  <%# 現在のスコア表示 %>
+  <div class="rally-current-score mb-3">
+    <span class="rally-score-label">現在のスコア：</span>
+    <span class="rally-score-value" data-rally-input-target="currentScore">0 - 0</span>
+  </div>
+
+  <%# ステップ1: 誰が得点した？ %>
+  <div class="rally-step rally-step1" data-rally-input-target="step1">
+    <div class="rally-step-title mb-2">誰が得点した？</div>
+    <div class="rally-winner-buttons">
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->rally-input#selectWinner"
+              data-winner="player">
+        自分の得点
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-opponent"
+              data-action="click->rally-input#selectWinner"
+              data-winner="opponent">
+        相手の得点
+      </button>
+    </div>
+  </div>
+
+  <%# ステップ2: どの技術で？ %>
+  <div class="rally-step rally-step2 d-none" data-rally-input-target="step2">
+    <div class="rally-step-title mb-2">どの技術で得点した？</div>
+    <div class="rally-style-buttons" data-rally-input-target="styleButtons">
+      <%# JS で動的に描画 %>
+    </div>
+    <div class="text-center mt-2">
+      <button type="button" class="btn rally-show-more-btn"
+              data-action="click->rally-input#toggleShowMore"
+              data-rally-input-target="showMore">
+        もっと見る ▼
+      </button>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->rally-input#undo">
+        ← 戻る
+      </button>
+    </div>
+  </div>
+
+  <%# 入力済みラリー一覧 %>
+  <div class="rally-list-section mt-3">
+    <div class="rally-list-header">入力済みラリー</div>
+    <div class="rally-list" data-rally-input-target="rallyList">
+      <div class="rally-list-empty">まだラリーが入力されていません</div>
+    </div>
+  </div>
+
+  <%# hidden field (フォーム送信用) — _form.html.erb 側で追加 %>
+</div>

--- a/app/views/match_infos/_rally_input.html.erb
+++ b/app/views/match_infos/_rally_input.html.erb
@@ -1,6 +1,30 @@
 <% initial_rallies = local_assigns[:initial_rallies] %>
+<% initial_first_server = local_assigns[:initial_first_server] %>
 
 <div class="rally-input-container">
+
+  <%# サーブ選択エリア（未選択時のみ表示） %>
+  <div data-rally-input-target="serverSelect">
+    <div class="rally-server-select-title mb-2">誰がサーブ？</div>
+    <div class="rally-server-buttons">
+      <button type="button" class="btn rally-server-btn rally-server-player"
+              data-action="click->rally-input#selectServer"
+              data-server="player">
+        自分がサーブ
+      </button>
+      <button type="button" class="btn rally-server-btn rally-server-opponent"
+              data-action="click->rally-input#selectServer"
+              data-server="opponent">
+        相手がサーブ
+      </button>
+    </div>
+  </div>
+
+  <%# サーバーインジケーター（サーブ選択後に表示） %>
+  <div class="rally-server-indicator d-none" data-rally-input-target="serverIndicator"></div>
+
+  <%# hidden field: first_server %>
+  <input type="hidden" name="first_server" data-rally-input-target="firstServerField">
 
   <%# 現在のスコア表示 %>
   <div class="rally-current-score mb-3">
@@ -8,8 +32,8 @@
     <span class="rally-score-value" data-rally-input-target="currentScore">0 - 0</span>
   </div>
 
-  <%# ステップ1: 誰が得点した？ %>
-  <div class="rally-step rally-step1" data-rally-input-target="step1">
+  <%# ステップ1: 誰が得点した？（サーブ選択後に表示） %>
+  <div class="rally-step rally-step1 d-none" data-rally-input-target="step1">
     <div class="rally-step-title mb-2">誰が得点した？</div>
     <div class="rally-winner-buttons">
       <button type="button" class="btn rally-winner-btn rally-winner-player"

--- a/app/views/match_infos/_rally_input.html.erb
+++ b/app/views/match_infos/_rally_input.html.erb
@@ -4,18 +4,18 @@
 <div class="rally-input-container">
 
   <%# サーブ選択エリア（未選択時のみ表示） %>
-  <div data-rally-input-target="serverSelect">
-    <div class="rally-server-select-title mb-2">誰がサーブ？</div>
+  <div class="rally-server-select-area" data-rally-input-target="serverSelect">
+    <div class="rally-server-select-title mb-3">🏓誰からサーブ？</div>
     <div class="rally-server-buttons">
       <button type="button" class="btn rally-server-btn rally-server-player"
               data-action="click->rally-input#selectServer"
               data-server="player">
-        自分がサーブ
+        自分からサーブ
       </button>
       <button type="button" class="btn rally-server-btn rally-server-opponent"
               data-action="click->rally-input#selectServer"
               data-server="opponent">
-        相手がサーブ
+        相手からサーブ
       </button>
     </div>
   </div>

--- a/db/migrate/20260518052507_add_first_server_to_games.rb
+++ b/db/migrate/20260518052507_add_first_server_to_games.rb
@@ -1,0 +1,5 @@
+class AddFirstServerToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :first_server, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_16_000001) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_18_052507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_16_000001) do
     t.datetime "updated_at", null: false
     t.integer "player_score"
     t.integer "opponent_score"
+    t.integer "first_server"
     t.index ["match_info_id"], name: "index_games_on_match_info_id"
   end
 

--- a/plans/a-ui-gleaming-honey.md
+++ b/plans/a-ui-gleaming-honey.md
@@ -174,6 +174,13 @@ id, match_info_id, game_id (nullable), game_number, sequence_number, winner (enu
 **auto_save_controller.js の変更:**
 - 既存の score フィールド収集ロジックを rally リストの収集に置き換え
 
+**サーブ権トラッキング（Sprint 2 追加）:**
+- ゲーム開始前に「誰がサーブ？」ボタンを1回選択
+- ゲーム内のサーブ権は自動追跡（2本交代、デュース後1本交代）
+- ゲーム間は前ゲームの反対側が自動的にデフォルトになる
+- `games.first_server` カラム（nullable）に保存
+- データ収集のみ。分析活用は Sprint 4 以降
+
 ---
 
 ### Sprint 3: 得点推移表（Showページ）

--- a/plans/sprint-2-ui-pr-partitioned-mountain.md
+++ b/plans/sprint-2-ui-pr-partitioned-mountain.md
@@ -1,0 +1,146 @@
+# Sprint 2 追加: サーブ権トラッキング
+
+## Context
+
+Sprint 2（ラリー入力UI）は実装・評価済み（feature/sprint-2-rally-input-ui ブランチ）。
+PR 作成前に「誰がサーブ権を持っているか」のデータ収集を追加する。
+
+現在はラリーに `batting_style: serve / receive` は記録できるが、
+「そのラリーでサーバーがどちらか」が未記録。このデータがないと
+サーブゲーム得点率・3球目攻撃成功率などの分析が将来的に不可能になる。
+
+**今回の目的**: データ収集のみ。分析機能への活用は Sprint 4（AI分析強化）以降。
+
+---
+
+## 実装方針
+
+### サーブ権の導出ルール（卓球の規則）
+
+```
+通常時（合計得点 < 20）: Math.floor(total / 2) % 2 === 0 → first_server が現在のサーバー
+デュース時（合計得点 >= 20）: total % 2 === 0 → first_server が現在のサーバー
+ゲーム間: 前ゲームの first_server の反対がデフォルト（変更可能）
+```
+
+各 Rally レコードには `server` を保存しない。
+`games.first_server` と `sequence_number` から常に導出できるため。
+
+---
+
+## 変更ファイル一覧
+
+### 1. `db/migrate/XXXXXX_add_first_server_to_games.rb`（新規）
+
+```ruby
+add_column :games, :first_server, :integer
+```
+
+nullable（既存データは nil のまま）。
+
+### 2. `app/models/game.rb`
+
+```ruby
+enum :first_server, { player: 0, opponent: 1 }
+```
+
+### 3. `app/views/match_infos/_rally_input.html.erb`
+
+- 「ラリー入力エリア」の前に「サーブ選択エリア」を追加
+- `data-rally-input-target="serverSelect"` ブロック（ゲーム開始前のみ表示）
+- 「自分がサーブ」「相手がサーブ」ボタン
+- 選択後は非表示、現在サーバーインジケーターに切り替わる（「🏓 自分のサーブ中」）
+- hidden field: `<input type="hidden" name="first_server" data-rally-input-target="firstServerField">`
+
+```
+[サーブ選択エリア（未選択時のみ表示）]
+誰がサーブ？
+[  自分がサーブ  ]   [  相手がサーブ  ]
+
+[ラリー入力エリア（サーブ選択後に表示）]
+🏓 自分のサーブ中  現在のスコア: 自分 0 - 相手 0
+
+ステップ1: 誰が得点した？
+[  自分の得点  ]   [  相手の得点  ]
+```
+
+### 4. `app/javascript/controllers/rally_input_controller.js`
+
+追加する状態:
+- `this.firstServer` — 'player' | 'opponent' | null（未選択）
+
+追加するメソッド:
+- `selectServer(event)` — サーバー選択ボタンのハンドラ。serverSelect を非表示、step1 を表示
+- `getCurrentServer()` — rallies の長さから現在のサーブ権を計算して返す
+- `getServerLabel()` — '自分のサーブ中' / '相手のサーブ中' を返す（UI表示用）
+
+変更するメソッド:
+- `connect()` — initialFirstServer value があれば this.firstServer を設定、サーブ選択 UI の表示/非表示を制御
+- `updateScore()` — サーバーインジケーターのテキストも更新
+- `serializeRallies()` — firstServerField に this.firstServer をセット
+- `endGame()` — firstServer が未選択のままゲーム終了を押せないようガード
+
+ゲーム間の引き継ぎ:
+- ゲーム終了後、次ゲーム開始時のデフォルトサーバーを前ゲームの反対に自動設定
+- `data-rally-input-value-initial-first-server` に前ゲームの opposite を渡す（フォーム側で制御）
+
+### 5. `app/controllers/match_infos_controller.rb`
+
+`create_game_from_rallies` を更新:
+
+```ruby
+def create_game_from_rallies(match_info)
+  rallies_data = JSON.parse(params[:rallies])
+  first_server = params[:first_server].presence  # 'player' or 'opponent' or nil
+  game_number = match_info.games.count + 1
+  player_total = rallies_data.count { |r| r['winner'] == 'player' }
+  opponent_total = rallies_data.count { |r| r['winner'] == 'opponent' }
+  game = match_info.games.create!(
+    game_number: game_number,
+    player_score: player_total,
+    opponent_score: opponent_total,
+    first_server: first_server
+  )
+  # 以降は既存処理
+end
+```
+
+`restore_last_game_to_partial_data` を更新:
+- `partial_game_data` に `'first_server'` も保存（undo 時に復元できるように）
+
+### 6. `plans/a-ui-gleaming-honey.md`
+
+Sprint 2 セクションに以下を追記:
+
+```markdown
+**サーブ権トラッキング（Sprint 2 追加）:**
+- ゲーム開始前に「誰がサーブ？」ボタンを1回選択
+- ゲーム内のサーブ権は自動追跡（2本交代、デュース後1本交代）
+- ゲーム間は前ゲームの反対側が自動的にデフォルトになる
+- `games.first_server` カラム（nullable）に保存
+- データ収集のみ。分析活用は Sprint 4 以降
+```
+
+### 7. `spec/models/game_spec.rb`
+
+`first_server` enum のテストを追加。
+
+---
+
+## 検証方法
+
+1. `bundle exec rspec && bundle exec rubocop --parallel` 両方パス
+2. Playwright で:
+   - `/match_infos/new` → サーブ選択UIが表示される
+   - 「自分がサーブ」を選択 → ラリー入力エリアが表示、「🏓 自分のサーブ中」表示
+   - 2本ごとにサーバーインジケーターが切り替わる
+   - 10-10 になったら1本交代に切り替わる
+   - 1ゲーム終了 → 2ゲーム目開始時に相手サーブがデフォルトになっている
+   - サーブ未選択のままゲーム終了ボタンが押せないこと（ガード確認）
+   - undo_game でサーブ権情報も復元されること
+
+---
+
+## 作業ブランチ
+
+既存ブランチ `feature/sprint-2-rally-input-ui` で作業継続。

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Game, type: :model do
+  describe 'enums' do
+    it { is_expected.to define_enum_for(:first_server).with_values(player: 0, opponent: 1) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:match_info) }
+    it { is_expected.to have_many(:scores).dependent(:destroy) }
+    it { is_expected.to have_many(:rallies).dependent(:destroy) }
+  end
+end

--- a/spec/system/match_infos_spec.rb
+++ b/spec/system/match_infos_spec.rb
@@ -43,27 +43,27 @@ RSpec.describe '試合情報の投稿', type: :system do
   end
 
   it 'ユーザーが試合情報を投稿し、詳細ページに表示される' do
-    visit login_path
-    fill_in 'メールアドレス', with: user.email
-    fill_in 'パスワード', with: 'password'
-    click_button 'ログイン'
+    # rack_test ドライバで直接 POST してセッションを維持したまま詳細ページを確認する
+    page.driver.post login_path, email: user.email, password: 'password'
 
-    visit new_match_info_path
+    rallies = [
+      { 'winner' => 'player', 'batting_style' => 'serve' },
+      { 'winner' => 'opponent', 'batting_style' => 'serve' }
+    ]
+    page.driver.post match_infos_path, {
+      match_info: {
+        match_date: Time.zone.today,
+        match_name: 'テスト大会',
+        memo: 'テストメモです',
+        match_format: 5,
+        player_name: '田中',
+        opponent_name: '佐藤'
+      },
+      rallies: rallies.to_json
+    }
 
-    fill_in '🗓️日付', with: Time.zone.today
-    fill_in '🏆大会名', with: 'テスト大会'
-    fill_in '👤選手名', with: '田中'
-    fill_in '👤対戦相手名', with: '佐藤'
-    fill_in '🗒️メモ', with: 'テストメモです'
-
-    # game_scores[serve][score] など固定の名前でフィールドが並んでいる
-    all('input[name$="[score]"]')[0].fill_in with: 3
-    all('input[name$="[lost_score]"]')[0].fill_in with: 1
-
-    all('input[name$="[score]"]')[1].fill_in with: 2
-    all('input[name$="[lost_score]"]')[1].fill_in with: 1
-
-    click_button '🚀 試合を分析する'
+    match_info = MatchInfo.last
+    visit match_info_path(match_info)
 
     expect(page).to have_content 'テスト大会'
     expect(page).to have_content '田中'


### PR DESCRIPTION
## 概要

ラリー入力UIを新たに実装し、使いやすさを向上させました。1本ずつ「誰が得点したか」「どの技術で決めたか」を入力することで、技術別スコアを自動集計します。

## 実装内容

### Sprint 2 コア実装
- **2ステップ入力UI**: サーブ選択 → 得点者選択 → 技術選択の順で入力
- **リアルタイムスコア表示**: 入力のたびに現在スコアを即時更新
- **ラリー一覧表示**: 入力済みラリーを一覧表示し、最新1件は取り消しボタン付き
- **技術ボタンの折りたたみ**: よく使う技術を前面に表示し「もっと見る」で全技術を展開
- **サーブ権トラッキング**: 卓球ルールに基づいたサーブ権の自動計算・表示

### UI改善
- サーブ選択テキストを「が」→「から」に変更し🏓絵文字を追加
- サーブ選択ボタンをカード内センタリングのボタンデザインに統一（得点者ボタンと同様のスタイル）

### バグ修正
- バリデーションエラー時に入力済みラリーデータ・サーブ選択が消えてしまう問題を修正
- ページ再表示時に得点板のスコアが0のままになっていた問題を修正

## 確認方法

1. 試合分析フォーム（`/match_infos/new`）にアクセス
2. サーブ選択 → 得点者選択 → 技術選択の順でラリーを入力できることを確認
3. 日付・大会名などを未入力のままで「試合を分析する」を押し、バリデーションエラー後にラリーデータと得点板スコアが保持されることを確認

## 影響範囲

- `match_infos/new`（ラリー入力フォーム）
- `MatchInfosController#create`, `end_game`（ラリーデータの保存・復元）
- `rally_input_controller.js`（Stimulusコントローラー）
- `scoreboard_controller.js`（得点板の更新）

## チェックリスト

- [x] RuboCop をパスした
- [x] RSpec をパスした（77 examples, 0 failures）
- [x] 動作確認済み

Closes #