### PR TITLE
feat: Sprint 1 — サーブ・レシーブ起点分析のデータ基盤

### DIFF
--- a/app/models/match_info.rb
+++ b/app/models/match_info.rb
@@ -6,8 +6,11 @@ class MatchInfo < ApplicationRecord
   accepts_nested_attributes_for :scores, update_only: true
   has_many :games, dependent: :destroy
   has_many :rallies, dependent: :destroy
+  has_many :serve_receive_patterns, dependent: :destroy
   accepts_nested_attributes_for :games
   attr_accessor :player_name, :opponent_name
+
+  enum :analysis_type, { technique: 0, serve_receive: 1 }
 
   validates :match_date, presence: true
   validates :match_name, presence: true

--- a/app/models/serve_receive_pattern.rb
+++ b/app/models/serve_receive_pattern.rb
@@ -1,0 +1,47 @@
+class ServeReceivePattern < ApplicationRecord
+  belongs_to :match_info
+  belongs_to :game, optional: true
+
+  enum :origin, { serve: 0, receive: 1 }, prefix: :origin
+  enum :serve_length, { long: 0, half_long: 1, short: 2 }
+  enum :decided_at, { attack_ball: 0, follow_ball: 1, rally: 2 }
+  enum :attack_style, {
+    fore_drive_vs_topspin: 15, back_drive_vs_topspin: 16,
+    fore_drive_vs_backspin: 17, back_drive_vs_backspin: 18,
+    fore_push: 4, back_push: 5,
+    fore_stop: 6, back_stop: 7,
+    fore_flick: 8, back_flick: 9,
+    chiquita: 10, fore_block: 11,
+    back_block: 12, fore_counter: 13,
+    back_counter: 14,
+    fore_smash: 19, back_smash: 20,
+    net_or_edge: 21
+  }, prefix: :attack
+
+  # receive_style は attack_style と同一のキー・整数マッピングを持つため enum 定義は行わない。
+  # 表示時は Score.human_enum_name(:batting_style, key) を利用すること。
+  RECEIVE_STYLE_VALUES = {
+    fore_drive_vs_topspin: 15, back_drive_vs_topspin: 16,
+    fore_drive_vs_backspin: 17, back_drive_vs_backspin: 18,
+    fore_push: 4, back_push: 5,
+    fore_stop: 6, back_stop: 7,
+    fore_flick: 8, back_flick: 9,
+    chiquita: 10, fore_block: 11,
+    back_block: 12, fore_counter: 13,
+    back_counter: 14,
+    fore_smash: 19, back_smash: 20,
+    net_or_edge: 21
+  }.freeze
+
+  SERVE_SPINS = { backspin: 0, topspin: 1, no_spin: 2, pro_sidespin: 3, anti_sidespin: 4 }.freeze
+  SERVE_SPIN_NAMES_JA = {
+    0 => '下回転', 1 => '上回転', 2 => 'ナックル', 3 => '順横回転', 4 => '逆横回転'
+  }.freeze
+
+  validates :origin, :attack_style, :decided_at, :game_number, :sequence_number, presence: true
+  validates :won, inclusion: { in: [true, false] }
+
+  def self.allowed_attack_styles
+    attack_styles.keys
+  end
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,6 +36,24 @@ ja:
           fore_smash: フォアスマッシュ
           back_smash: バックスマッシュ
           net_or_edge: ネットorエッジ
+      serve_receive_pattern:
+        origin:
+          serve: 自分のサーブ
+          receive: 自分のレシーブ
+        serve_length:
+          long: ロング
+          half_long: ハーフロング
+          short: ショート
+        decided_at:
+          attack_ball: 3・4球目
+          follow_ball: 5・6球目
+          rally: ラリー
+        serve_spin:
+          backspin: 下回転
+          topspin: 上回転
+          no_spin: ナックル
+          pro_sidespin: 順横回転
+          anti_sidespin: 逆横回転
   defaults:
     password_reset: "パスワードリセットのご案内"
   notices:

--- a/db/migrate/20260518060000_add_analysis_type_to_match_infos.rb
+++ b/db/migrate/20260518060000_add_analysis_type_to_match_infos.rb
@@ -1,0 +1,5 @@
+class AddAnalysisTypeToMatchInfos < ActiveRecord::Migration[7.1]
+  def change
+    add_column :match_infos, :analysis_type, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20260518060001_create_serve_receive_patterns.rb
+++ b/db/migrate/20260518060001_create_serve_receive_patterns.rb
@@ -1,0 +1,20 @@
+class CreateServeReceivePatterns < ActiveRecord::Migration[7.1]
+  def change
+    create_table :serve_receive_patterns do |t|
+      t.references :match_info, null: false, foreign_key: true
+      t.references :game, null: true, foreign_key: true
+      t.integer :game_number, null: false
+      t.integer :sequence_number, null: false
+      t.integer :origin, null: false
+      t.integer :serve_length
+      t.integer :serve_spins, array: true, default: []
+      t.integer :receive_style
+      t.integer :attack_style, null: false
+      t.integer :decided_at, null: false
+      t.boolean :won, null: false
+      t.timestamps
+    end
+    add_index :serve_receive_patterns, [:match_info_id, :game_number, :sequence_number],
+              unique: true, name: 'index_srp_on_match_info_game_sequence'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_18_052507) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_18_060001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_052507) do
     t.integer "match_format", default: 5
     t.boolean "draft", default: false, null: false
     t.jsonb "partial_game_data"
+    t.integer "analysis_type", default: 0, null: false
     t.index ["opponent_id"], name: "index_match_infos_on_opponent_id"
     t.index ["player_id"], name: "index_match_infos_on_player_id"
     t.index ["user_id"], name: "index_match_infos_on_user_id"
@@ -75,6 +76,25 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_052507) do
     t.index ["match_info_id"], name: "index_scores_on_match_info_id"
   end
 
+  create_table "serve_receive_patterns", force: :cascade do |t|
+    t.bigint "match_info_id", null: false
+    t.bigint "game_id"
+    t.integer "game_number", null: false
+    t.integer "sequence_number", null: false
+    t.integer "origin", null: false
+    t.integer "serve_length"
+    t.integer "serve_spins", default: [], array: true
+    t.integer "receive_style"
+    t.integer "attack_style", null: false
+    t.integer "decided_at", null: false
+    t.boolean "won", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_serve_receive_patterns_on_game_id"
+    t.index ["match_info_id", "game_number", "sequence_number"], name: "index_srp_on_match_info_game_sequence", unique: true
+    t.index ["match_info_id"], name: "index_serve_receive_patterns_on_match_info_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
@@ -100,4 +120,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_052507) do
   add_foreign_key "rallies", "match_infos"
   add_foreign_key "scores", "games"
   add_foreign_key "scores", "match_infos"
+  add_foreign_key "serve_receive_patterns", "games"
+  add_foreign_key "serve_receive_patterns", "match_infos"
 end

--- a/plans/77-phase-0-77-1-replicated-twilight.md
+++ b/plans/77-phase-0-77-1-replicated-twilight.md
@@ -1,0 +1,172 @@
+# #77 サーブ・レシーブ起点の3球目/4球目パターン分析 ＋ 今後の実装ロードマップ
+
+## Context（なぜこの実装をするのか）
+
+T.T.LOG は現在「1試合を深く分析する」機能（ラリー単位入力・得点推移表・技術別得点ランキング・文脈リッチなAIアドバイス）が高い完成度にある一方、複数試合をまたいだ成長分析や収益化基盤は未実装である。
+
+今後は「積み上げ型 SaaS（卓球プレイヤーの成長データ基盤）」へ進化させ、最終的にフリーミアム課金（閲覧制限型）で収益化する方針。その第一歩として、卓球経験者に最も刺さる差別化機能 **#77「サーブ・レシーブ起点の3球目/4球目パターン分析」** から着手する。
+
+この機能は既存の「技術別得点率」分析とは**完全に独立した、もう一つの分析機能**。卓球で重要な「サーブからの3球目」「レシーブからの4球目」の連鎖を記録・分析する。
+例:「ショート下回転サーブを出して3球目で対下回転フォアドライブを打って得点」。
+
+ユーザー承認済みの設計方針:
+
+- **完全独立フロー** — 既存の試合入力には一切手を入れず、別の入力画面・別の分析として並走させることで「普段の入力は軽いまま、深く分析したい人だけ使う」を実現する（入力負荷の増大を回避）。
+- 入力画面には**現在と同じ仕様の試合情報（日付・大会名・選手名 autocomplete）と得点板**を設置する。
+
+---
+
+# Part 1: #77 実装プラン（今すぐ着手）
+
+## 確定仕様
+
+### 入力フロー
+
+- **入口**: 試合分析一覧ページ（`match_infos#index`）に新規ボタンを設置 → 専用入力ページへ。
+- **構成**: 試合情報（既存と同じ）＋ 得点板 ＋ サーブ権選択 ＋ 得点ごとのパターン入力。ゲーム単位で進行（ゲーム終了→次ゲーム→試合終了→分析表示）。
+- 「自分のサーブ」か「自分のレシーブ」かは `first_server` ＋ 得点順から**自動判定**（既存ロジック流用、後述）。
+
+### 記録内容（1得点 = 1レコード）
+
+- **サーブ起点**: ①サーブの種類（長さ1つ＋回転 複数選択可）②3球目の技術 ③結果
+- **レシーブ起点**: ①レシーブの種類 ②4球目の技術 ③結果
+- **サーブの長さ**: ロング / ハーフロング / ショート（1つ）
+- **サーブの回転**: 下回転 / 上回転 / ナックル / 順横回転 / 逆横回転（**複数選択可**。例「順横回転＋下回転＝順横下回転」）
+- **技術（3球目/4球目/レシーブ）**: 既存 `batting_style` enum の **serve を除いた値**。ドライブ系は対◯回転を内包（`fore_drive_vs_backspin` = 対下回転フォアドライブ）。
+- **結果（6種類）**: 決着タイミング × 勝敗
+  - サーブ起点: 3球目で得点/失点 ・ 5球目で得点/失点 ・ 7球目以降で得点/失点
+  - レシーブ起点: 4球目で得点/失点 ・ 6球目で得点/失点 ・ 8球目以降で得点/失点
+  - 内部表現: `decided_at`（attack_ball=3or4球目 / follow_ball=5or6球目 / rally=サーブ起点:7球目以降/レシーブ起点:8球目以降）× `won`（boolean）。`won` で得点板を増減。
+
+## データモデル
+
+### MatchInfo に相乗り（別モデルにしない）
+
+`app/models/match_info.rb` に `enum :analysis_type, { technique: 0, serve_receive: 1 }`（default 0）を追加。
+
+- **理由**: 試合情報フィールド・autocomplete・`find_or_create_players`・`draft_or_new_match_info`・ドラフト機構・scoreboard partial をそのまま流用できる。別モデル化すると Player 関連 / ransack / autocomplete / pagy を二重実装するコストが大きい。
+- 既存試合は自動で `technique` 扱い（後方互換）。`index` / `show` は `analysis_type` で分岐。
+
+### 新テーブル `serve_receive_patterns`
+
+
+| カラム             | 型                                 | 備考                                      |
+| --------------- | --------------------------------- | --------------------------------------- |
+| match_info_id   | references, null: false           | FK                                      |
+| game_id         | references, null: true            | FK（rallies の流儀）                         |
+| game_number     | integer, null: false              |                                         |
+| sequence_number | integer, null: false              | ゲーム内の得点順                                |
+| origin          | integer, null: false              | enum: serve / receive                   |
+| serve_length    | integer, null: true               | enum: long / half_long / short          |
+| serve_spins     | integer, array: true, default: [] | 回転の複数選択（Postgres array）                 |
+| receive_style   | integer, null: true               | batting_style 値（レシーブ起点時）                |
+| attack_style    | integer, null: true               | batting_style 値（3球目 or 4球目）             |
+| decided_at      | integer, null: false              | enum: attack_ball / follow_ball / rally |
+| won             | boolean, null: false              | true=自分の得点                              |
+| timestamps      |                                   |                                         |
+
+
+- 複合 unique index: `[match_info_id, game_number, sequence_number]`（create_table 外で `add_index`）。
+- **回転の複数選択は integer 配列列**（`t.integer :serve_spins, array: true, default: []`）。中間テーブルは過剰、jsonb は要素別集計に不向き。回転は固定5種で集計が容易。
+- 回転・長さは batting_style とは別概念なので、モデルに独自定数で定義（enum 重複を避ける）:
+  - `SERVE_LENGTHS = %i[long half_long short]`
+  - `SERVE_SPINS = %i[backspin topspin no_spin pro_sidespin reverse_sidespin]`
+
+## 再利用する既存実装（新規作成しない）
+
+
+| 用途      | 流用元                                                                                                                                                                                                      |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| サーブ自動判定 | `app/services/rally_context_builder.rb` の `my_serve?(game, sequence_number)`（2点交代・デュース対応済み）→ 共有メソッド化して origin 判定に流用                                                                                      |
+| 入力UIの型  | `app/views/match_infos/_form.html.erb`（form_with + Stimulus + hidden field JSON送信）、`_rally_input.html.erb`（サーブ権→段階入力UI）                                                                                  |
+| 入力JSの型  | `app/javascript/controllers/rally_input_controller.js`（配列を貯めて hidden input に JSON化、技術ボタン動的生成、`getCurrentServer()`）                                                                                       |
+| 得点板     | `app/javascript/controllers/scoreboard_controller.js`（`rally:scoreUpdated` イベント受信。**無変更で流用**）                                                                                                            |
+| 保存処理の型  | `match_infos_controller.rb` の `create`→`create_game_from_rallies`→`create_game_record_from_rallies`/`persist_rally_records` の鏡像を新設。`find_or_create_players`/`draft_or_new_match_info`/`autocomplete` は流用 |
+| 分析表示    | `app/views/match_infos/_batting_score_table.html.erb`（theme: :player(青)/:opponent(赤)、構成比バー）、`app/helpers/application_helper.rb` の `append_share`/`build_aggregated_score_data`                           |
+| 技術の和名   | `Score.human_enum_name(:batting_style, ...)`（新 I18n キー不要）                                                                                                                                                |
+
+
+## スプリント分割（各スプリント末で `bundle exec rspec && bundle exec rubocop --parallel` が緑）
+
+### Sprint 1 — データ基盤（`feature/sprint-1-serve-receive-model`）
+
+- migration ×2: `AddAnalysisTypeToMatchInfos`、`CreateServeReceivePatterns`（schema 版 `2026_05_18_052507` より後のタイムスタンプ）
+- `app/models/serve_receive_pattern.rb` 新規（enum・定数・バリデーション・関連）
+- `app/models/match_info.rb` に `analysis_type` enum と `has_many :serve_receive_patterns` 追記
+- I18n（回転・長さ・決着タイミングの和名）、factory、model spec
+
+### Sprint 2 — 独立入力フロー（`feature/sprint-2-serve-receive-input`）
+
+- `config/routes.rb`: collection に `new_serve_receive` / `create_serve_receive` / `end_game_serve_receive` を追加
+- `match_infos_controller.rb`: 上記アクション ＋ `create_game_from_patterns` 系 private メソッド
+- View: `new_serve_receive` ＋ `_serve_receive_form` ＋ `_serve_receive_input`（試合情報・得点板は既存 partial 流用）
+- `app/javascript/controllers/serve_receive_input_controller.js` 新規（origin 自動判定 → サーブ種類 複数選択 or レシーブ技術 → 攻撃技術 → 結果6ボタン → 次の得点。得点板連携）
+- `index` 開始ボタン設置、request spec
+
+### Sprint 3 — 専用分析ページ（`feature/sprint-3-serve-receive-analysis`）
+
+- `app/services/serve_receive_analyzer.rb` 新規（集計）＋ service spec
+- `show` に `if @match_info.serve_receive?` 分岐、`_serve_receive_analysis` partial
+- 集計軸: ①サーブ別得点率 ②サーブ→3球目パターン別 ③レシーブ別 ④レシーブ→4球目パターン別 ⑤決着タイミング分布
+- 表示は `_batting_score_table` 流用。組合せ別パターン（長さ＋回転＋3球目）は単一 batting_style キーで表せないため、ラベル文字列を受け取れる薄い派生 partial を用意（or `Score.human_enum_name` 直挿し部分を locals 化する小改修）
+
+### Sprint 4 — UX強化＋AI連携（任意・`feature/sprint-4-serve-receive-ux`）
+
+- 中断（interrupt）/ 前ゲームに戻る（undo）/ auto_save の新フロー対応
+- `index` に analysis_type バッジ表示
+- AIアドバイス連携（サーブ・レシーブ特化のプロンプト。`RallyContextBuilder` 流の `ServeReceiveContextBuilder`）
+- system spec
+
+## 検証方法（end-to-end）
+
+1. `bundle exec rspec && bundle exec rubocop --parallel` が両方パス
+2. `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` が 200
+3. ブラウザ操作: 一覧 → 新規ボタン → 試合情報入力 → サーブ権選択 → サーブ起点（ショート＋下回転＋順横回転 / 3球目 fore_drive_vs_backspin / 3球目で得点）とレシーブ起点の両方を数点入力 → ゲーム終了 → 試合終了 → 分析ページで5軸の集計が正しく表示されることを確認
+
+## 重要な注意点
+
+- `analysis_type` のデフォルト 0=technique により、既存の試合入力フロー（`create`/`end_game`/`_form`/`_rally_input`）には一切手を入れずに済む。新フローは別アクション・別 partial・別 Stimulus controller で**完全並走**。
+- enum はリポジトリの流儀どおりモデルに再掲（Score/Rally と同様のベタ書き）。
+
+---
+
+# Part 2: #77 以降のロードマップ（記録用）
+
+> #77 完了後の方向性。各 Phase 着手時に改めて planner で詳細仕様を起こす。基本思想は「積み上げ型の価値はカレンダー時間でしか育たない → 集計基盤を早く出してデータ時計を回し、蓄積が育った頃に閲覧制限型フリーミアムで課金開始」。
+
+## Phase 0: データ集計基盤 ＋ 成長ダッシュボード
+
+- 複数試合をまたいだ技術別得点率の集計、月別/週別の時系列グラフ
+- まずは「フォアドライブの得点率推移を月別表示」から作り、他分析に応用
+- **狙い**: 既存データだけで作れて初日から価値が出る・低リスク・「積み上げは刺さるか」を最安で検証。データ時計を最速で回す。
+
+## Phase 1: 対戦相手タイプ ＋ タイプ別分析
+
+- 試合登録時に対戦相手タイプを選択（ドライブ型/カットマン/前陣速攻/ブロック型/サウスポー/ペンホルダー/その他）
+- タイプ別勝率・技術別得点率。#77 と掛け合わせて「カットマン相手の3球目決定率」等が可能に
+- **狙い**: 強い差別化ポイント。Phase 0 の集計エンジン上に軽く乗る。
+
+## Phase 2: AI長期メモリ ＋ 月間成長レポート ＋ 練習メニュー提案
+
+- 過去アドバイスの「要約」を保存し次回プロンプトへ（自分専用AIコーチ化、APIコスト配慮）
+- 月間成長レポートのAI生成、練習メニュー提案
+- **狙い**: 継続率を底上げ。Phase 0-1 で育ったデータがあって初めて中身が伴う。
+
+## Phase 3: 収益化基盤の導入 💰課金開始
+
+- Stripe 等の課金基盤
+- **閲覧制限型フリーミアム**: 無料=直近◯試合＋基本分析、premium=長期推移/対戦相手分析/#77/AI履歴/成長レポート（データは消さず「価値ある分析だけ」を制限）
+- premium に**初月無料トライアル**を付与（「初月無料・全機能有料」ではなく、永続無料枠＋premiumお試し）
+- **狙い**: 売るに値する蓄積価値と、手放したくないユーザーが揃ってから課金。
+
+## Phase 4: 用具データ連携（後回しでよい）
+
+- ラバー/ラケット変更前後の比較、用具別勝率、AIによる用具提案
+- **狙い**: 面白い差別化だが収益化の堀の本体ではない。課金開始後で十分。
+
+## Phase 5: コミュニティ機能（収益化が回ってから）
+
+- 成長共有（得点率の伸びをSNS投稿）→ いいね/コメント → クラブ/ランキング/チャレンジ
+- ランキングは「勝率」より「成長系（最も改善した人・継続記録）」を優先（初心者が萎えない設計）
+- **狙い**: Strava 型の継続フック。ただし分析価値が先、SNS化は最後。
+

--- a/spec/factories/serve_receive_patterns.rb
+++ b/spec/factories/serve_receive_patterns.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :serve_receive_pattern do
+    association :match_info
+    association :game
+    game_number { 1 }
+    sequence_number { 1 }
+    origin { :serve }
+    serve_length { :short }
+    serve_spins { [0] }
+    attack_style { :fore_drive_vs_backspin }
+    decided_at { :attack_ball }
+    won { true }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { "テスト太郎" }
-    email { "test@example.com" }
+    sequence(:email) { |n| "test#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/models/match_info_spec.rb
+++ b/spec/models/match_info_spec.rb
@@ -83,4 +83,24 @@ RSpec.describe MatchInfo, type: :model do
       end
     end
   end
+
+  describe "analysis_type enum" do
+    it "デフォルトでtechniqueであること" do
+      match_info = FactoryBot.create(:match_info)
+      expect(match_info.technique?).to be true
+    end
+
+    it "serve_receiveに変更できること" do
+      match_info = FactoryBot.create(:match_info)
+      match_info.serve_receive!
+      expect(match_info.serve_receive?).to be true
+    end
+  end
+
+  describe "serve_receive_patterns関連" do
+    it "has_many serve_receive_patternsを持つこと" do
+      match_info = FactoryBot.create(:match_info)
+      expect(match_info).to respond_to(:serve_receive_patterns)
+    end
+  end
 end

--- a/spec/models/serve_receive_pattern_spec.rb
+++ b/spec/models/serve_receive_pattern_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe ServeReceivePattern, type: :model do
+  describe "バリデーション" do
+    it "有効な属性で有効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern)
+      expect(pattern).to be_valid
+    end
+
+    it "originが無いと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, origin: nil)
+      expect(pattern).to be_invalid
+    end
+
+    it "attack_styleが無いと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, attack_style: nil)
+      expect(pattern).to be_invalid
+    end
+
+    it "decided_atが無いと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, decided_at: nil)
+      expect(pattern).to be_invalid
+    end
+
+    it "game_numberが無いと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, game_number: nil)
+      expect(pattern).to be_invalid
+    end
+
+    it "sequence_numberが無いと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, sequence_number: nil)
+      expect(pattern).to be_invalid
+    end
+
+    it "wonがtrueで有効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, won: true)
+      expect(pattern).to be_valid
+    end
+
+    it "wonがfalseで有効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, won: false)
+      expect(pattern).to be_valid
+    end
+
+    it "wonがnilだと無効になること" do
+      pattern = FactoryBot.build(:serve_receive_pattern, won: nil)
+      expect(pattern).to be_invalid
+    end
+  end
+
+  describe "enum" do
+    it "originのenumが正しく定義されていること" do
+      expect(ServeReceivePattern.origins).to eq({ 'serve' => 0, 'receive' => 1 })
+    end
+
+    it "serve_lengthのenumが正しく定義されていること" do
+      expect(ServeReceivePattern.serve_lengths).to eq({ 'long' => 0, 'half_long' => 1, 'short' => 2 })
+    end
+
+    it "decided_atのenumが正しく定義されていること" do
+      expect(ServeReceivePattern.decided_ats).to eq({ 'attack_ball' => 0, 'follow_ball' => 1, 'rally' => 2 })
+    end
+  end
+
+  describe "定数" do
+    it "SERVE_SPINSが正しく定義されていること" do
+      expect(ServeReceivePattern::SERVE_SPINS).to include(:backspin, :topspin, :no_spin, :pro_sidespin, :anti_sidespin)
+    end
+  end
+
+  describe ".allowed_attack_styles" do
+    it "技術一覧を返すこと" do
+      allowed = ServeReceivePattern.allowed_attack_styles
+      expect(allowed).to include('fore_drive_vs_topspin', 'fore_drive_vs_backspin')
+    end
+  end
+
+  describe "serve_spinsの配列保存" do
+    let(:match_info) { FactoryBot.create(:match_info) }
+
+    it "複数の回転を配列で保存できること" do
+      pattern = FactoryBot.create(:serve_receive_pattern, match_info: match_info, serve_spins: [0, 3])
+      pattern.reload
+      expect(pattern.serve_spins).to eq([0, 3])
+    end
+  end
+end


### PR DESCRIPTION
## 概要

#77「サーブ・レシーブ起点の3球目/4球目パターン分析」機能の **Sprint 1** — データモデル層の実装。

既存の技術別得点率分析とは完全独立した第二の分析軸として、サーブ/レシーブ起点の連鎖を記録・分析する基盤を整備する。

## 変更内容

### マイグレーション
- `add_analysis_type_to_match_infos` — MatchInfo に `analysis_type` enum（`technique`=0 / `serve_receive`=1）を追加。既存データはデフォルト `technique(0)` で後方互換を維持。
- `create_serve_receive_patterns` — 1得点=1レコードで記録する新テーブルを追加。`game_number` × `sequence_number` の複合ユニークインデックスつき。

### モデル
- `MatchInfo` — `enum :analysis_type` / `has_many :serve_receive_patterns` を追加（既存メソッド無変更）。
- `ServeReceivePattern`（新規）— origin / serve_length / serve_spins（integer配列） / receive_style / attack_style / decided_at / won の各フィールドを定義。

### I18n
- `config/locales/ja.yml` に `serve_receive_pattern` の各 enum 和名を追加。

### テスト
- `spec/factories/serve_receive_patterns.rb`（新規）
- `spec/models/serve_receive_pattern_spec.rb`（新規） — enum / validation / `allowed_attack_styles` / spins 配列の検証
- `spec/models/match_info_spec.rb`（追記） — analysis_type enum / 関連

## 確認方法

1. `bundle exec rails db:migrate` を実行してください
2. `bundle exec rspec spec/models/serve_receive_pattern_spec.rb spec/models/match_info_spec.rb` でモデルスペックが通ることを確認してください
3. Railsコンソールで `ServeReceivePattern.new(origin: :serve, ...).valid?` などを試してレコード作成できることを確認してください

## 影響範囲

- `match_infos` テーブルへのカラム追加（デフォルト値あり、既存データに影響なし）
- 新テーブル `serve_receive_patterns` の追加
- `MatchInfo` モデルへの enum / has_many 追加（既存メソッドは無変更）

## チェックリスト

- [ ] `bundle exec rspec` パス
- [ ] `bundle exec rubocop --parallel` パス
- [ ] マイグレーションの後方互換を確認（既存 MatchInfo は全て `technique` 扱い）

## コメント

- `serve_spins` は PostgreSQL の integer 配列（`array: true`）で複数回転の同時指定を表現。既存に同様のカラムはないが Rails 標準機能で流儀違反ではない。
- `attack_style` / `receive_style` は batting_style と同じ整数マップを再掲。Score/Rally と同じ流儀でベタ書き。
- 入力UI・集計・分析表示は Sprint 2 / 3 で実装予定。

Refs #77