### PR TITLE
feat: Sprint 2 — サーブ・レシーブ入力フローの実装

### DIFF
--- a/app/assets/stylesheets/match_infos.scss
+++ b/app/assets/stylesheets/match_infos.scss
@@ -720,8 +720,18 @@ select {
   }
 }
 
+.rally-result-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
 .rally-winner-btn {
-  flex: 1;
+  width: 100%;
   padding: 0.875rem 1rem;
   font-size: 1rem;
   font-weight: bold;
@@ -767,10 +777,27 @@ select {
   color: var(--tt-text);
   transition: all 0.15s ease;
 
-  &:hover {
+  &:hover, &.active {
     background: var(--tt-primary);
     color: #fff;
     border-color: var(--tt-primary);
+  }
+}
+
+.rally-style-btn--ace {
+  font-weight: bold;
+}
+
+.rally-style-btn--miss {
+  font-weight: bold;
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #ef4444;
+
+  &:hover {
+    background: #ef4444;
+    color: #fff;
+    border-color: #ef4444;
   }
 }
 

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -121,6 +121,50 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     render partial: "match_infos/autocomplete_results", locals: { candidates: candidates.first(10) }
   end
 
+  def new_serve_receive
+    @match_info = MatchInfo.new
+    @match_info.analysis_type = :serve_receive
+    @draft_id = nil
+    @saved_games = []
+    @current_game_number = 1
+    @max_games = 5
+    @partial_scores = {}
+  end
+
+  def create_serve_receive # rubocop:disable Metrics/AbcSize
+    player, opponent = find_or_create_players
+    @match_info = draft_or_new_match_info(player, opponent)
+    @match_info.analysis_type = :serve_receive
+
+    respond_to do |format|
+      if @match_info.save
+        create_game_from_patterns(@match_info) if params[:patterns].present?
+        @match_info.update(draft: false)
+        format.html { redirect_to match_info_url(@match_info), notice: t('notices.match_info_created') }
+        format.json { render :show, status: :created, location: @match_info }
+      else
+        set_form_state_for_serve_receive_error
+        format.html { render :new_serve_receive, status: :unprocessable_entity }
+        format.json { render json: @match_info.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def end_game_serve_receive
+    player, opponent = find_or_create_players
+    @match_info = draft_or_new_match_info(player, opponent)
+    @match_info.analysis_type = :serve_receive
+
+    unless @match_info.valid?
+      set_form_state_for_serve_receive_error
+      render :new_serve_receive, status: :unprocessable_entity
+      return
+    end
+
+    persist_and_finalize_game_serve_receive
+    redirect_to new_serve_receive_match_infos_path(draft_id: @match_info.id)
+  end
+
   private
 
   def persist_and_finalize_game
@@ -363,6 +407,65 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
     )
     match_info.partial_game_data = JSON.parse(params[:game_scores] || '{}')
     match_info
+  end
+
+  def persist_and_finalize_game_serve_receive
+    @match_info.save! unless @match_info.persisted?
+    @match_info.save! if @match_info.changed?
+    create_game_from_patterns(@match_info) if params[:patterns].present?
+    @match_info.update!(draft: true, partial_game_data: nil)
+  end
+
+  def set_form_state_for_serve_receive_error
+    @draft_id = params[:draft_id]
+    @max_games = @match_info.match_format || 5
+    if @match_info.persisted?
+      @saved_games = @match_info.games.order(:game_number)
+      @current_game_number = @saved_games.count + 1
+    else
+      @saved_games = []
+      @current_game_number = 1
+    end
+  end
+
+  def create_game_from_patterns(match_info)
+    patterns_data = JSON.parse(params[:patterns])
+    return unless patterns_data.is_a?(Array) && patterns_data.any?
+
+    game = create_game_record_from_patterns(match_info, patterns_data)
+    persist_pattern_records(match_info, game, patterns_data, game.game_number)
+  rescue JSON::ParserError
+    nil
+  end
+
+  def create_game_record_from_patterns(match_info, patterns)
+    game_number = match_info.games.count + 1
+    player_total = patterns.count { |p| p['won'] == true }
+    opponent_total = patterns.count { |p| p['won'] == false }
+    first_server = params[:first_server].presence
+    match_info.games.create!(
+      game_number: game_number, player_score: player_total, opponent_score: opponent_total,
+      first_server: first_server
+    )
+  end
+
+  def persist_pattern_records(match_info, game, patterns, game_number)
+    patterns.each_with_index do |p, i|
+      spins = p['serve_spins']
+      spins = spins.is_a?(Array) ? spins.map(&:to_i) : []
+      match_info.serve_receive_patterns.create!(
+        game_id: game.id,
+        game_number: game_number,
+        sequence_number: i + 1,
+        origin: p['origin'],
+        serve_length: p['serve_length'].presence,
+        serve_spins: spins,
+        receive_style: p['receive_style'].presence,
+        attack_style: p['attack_style'],
+        decided_at: p['decided_at'],
+        won: p['won']
+      )
+    end
   end
 
   def basic_match_info_params

--- a/app/javascript/controllers/serve_receive_input_controller.js
+++ b/app/javascript/controllers/serve_receive_input_controller.js
@@ -20,7 +20,10 @@ const BATTING_STYLE_NAMES = {
   back_counter: 'バックカウンター',
   fore_smash: 'フォアスマッシュ',
   back_smash: 'バックスマッシュ',
-  net_or_edge: 'ネットorエッジ'
+  net_or_edge: 'ネットorエッジ',
+  service_ace: 'サービスエース',
+  receive_ace: 'レシーブエース',
+  receive_miss: 'レシーブミス'
 }
 
 const ATTACK_STYLES = Object.keys(BATTING_STYLE_NAMES).filter(s => s !== 'serve' && s !== 'receive')
@@ -140,6 +143,7 @@ export default class extends Controller {
       if (this.hasStepReceiveAttackTarget) this.stepReceiveAttackTarget.classList.remove('d-none')
     } else if (step === 'result') {
       if (this.hasStepResultTarget) this.stepResultTarget.classList.remove('d-none')
+      this.updateResultButtonLabels()
     }
   }
 
@@ -159,6 +163,10 @@ export default class extends Controller {
     const spin = parseInt(event.currentTarget.dataset.spin)
     const idx = this.selectedSpins.indexOf(spin)
     if (idx === -1) {
+      const exclusions = { 0: 1, 1: 0, 3: 4, 4: 3 }
+      if (exclusions[spin] !== undefined) {
+        this.selectedSpins = this.selectedSpins.filter(s => s !== exclusions[spin])
+      }
       this.selectedSpins.push(spin)
     } else {
       this.selectedSpins.splice(idx, 1)
@@ -199,7 +207,7 @@ export default class extends Controller {
     const won = event.currentTarget.dataset.won === 'true'
     const decidedAt = event.currentTarget.dataset.decidedAt
 
-    const pattern = {
+    this._commitPattern({
       origin: this.draft.origin,
       serve_length: this.draft.serve_length || null,
       serve_spins: this.draft.serve_spins || [],
@@ -207,16 +215,50 @@ export default class extends Controller {
       attack_style: this.draft.attack_style,
       decided_at: decidedAt,
       won: won
-    }
+    })
+  }
 
+  selectServiceAce() {
+    this._commitPattern({
+      origin: this.draft.origin,
+      serve_length: this.draft.serve_length || null,
+      serve_spins: this.draft.serve_spins || [],
+      receive_style: null,
+      attack_style: 'service_ace',
+      decided_at: 'attack_ball',
+      won: true
+    })
+  }
+
+  selectReceiveAce() {
+    this._commitPattern({
+      origin: this.draft.origin,
+      serve_length: null,
+      serve_spins: [],
+      receive_style: this.draft.receive_style || null,
+      attack_style: 'receive_ace',
+      decided_at: 'attack_ball',
+      won: true
+    })
+  }
+
+  selectReceiveMiss() {
+    this._commitPattern({
+      origin: this.draft.origin,
+      serve_length: null,
+      serve_spins: [],
+      receive_style: this.draft.receive_style || null,
+      attack_style: 'receive_miss',
+      decided_at: 'attack_ball',
+      won: false
+    })
+  }
+
+  _commitPattern(pattern) {
     this.patterns.push(pattern)
     this.draft = {}
     this.selectedSpins = []
-
-    // すべてのステップを隠す
     this.showStep('origin')
-    // origin step は即座に次の状態に進む（サーバーに従って自動）
-
     this.renderPatternList()
     this.updateScore()
     this.updateEndGameButton()
@@ -260,16 +302,20 @@ export default class extends Controller {
   // ========== レンダリング ==========
 
   renderAttackButtons() {
-    const html = ATTACK_STYLES.map(style => {
+    const regularStyles = ATTACK_STYLES.filter(s => s !== 'service_ace' && s !== 'receive_ace' && s !== 'receive_miss')
+
+    const serviceAceBtn = `<button type="button" class="btn rally-style-btn rally-style-btn--ace"
+      data-action="click->serve-receive-input#selectServiceAce">サービスエース</button>`
+    const serveHtml = serviceAceBtn + regularStyles.map(style => {
       const name = BATTING_STYLE_NAMES[style] || style
       return `<button type="button" class="btn rally-style-btn"
         data-action="click->serve-receive-input#selectServeAttack"
         data-style="${style}">${name}</button>`
     }).join('')
 
-    if (this.hasServeAttackButtonsTarget) this.serveAttackButtonsTarget.innerHTML = html
+    if (this.hasServeAttackButtonsTarget) this.serveAttackButtonsTarget.innerHTML = serveHtml
 
-    const receiveHtml = ATTACK_STYLES.map(style => {
+    const receiveHtml = regularStyles.map(style => {
       const name = BATTING_STYLE_NAMES[style] || style
       return `<button type="button" class="btn rally-style-btn"
         data-action="click->serve-receive-input#selectReceiveStyle"
@@ -278,7 +324,11 @@ export default class extends Controller {
 
     if (this.hasReceiveStyleButtonsTarget) this.receiveStyleButtonsTarget.innerHTML = receiveHtml
 
-    const receiveAttackHtml = ATTACK_STYLES.map(style => {
+    const receiveAceBtn = `<button type="button" class="btn rally-style-btn rally-style-btn--ace"
+      data-action="click->serve-receive-input#selectReceiveAce">レシーブエース</button>`
+    const receiveMissBtn = `<button type="button" class="btn rally-style-btn rally-style-btn--miss"
+      data-action="click->serve-receive-input#selectReceiveMiss">レシーブミス</button>`
+    const receiveAttackHtml = receiveAceBtn + receiveMissBtn + regularStyles.map(style => {
       const name = BATTING_STYLE_NAMES[style] || style
       return `<button type="button" class="btn rally-style-btn"
         data-action="click->serve-receive-input#selectReceiveAttack"
@@ -316,6 +366,32 @@ export default class extends Controller {
     }).join('')
 
     this.patternListTarget.innerHTML = items
+  }
+
+  updateResultButtonLabels() {
+    if (!this.hasStepResultTarget) return
+    const isReceive = this.draft.origin === 'receive'
+    const labels = isReceive
+      ? {
+          'true-attack_ball': '4球目で自分が得点',
+          'false-attack_ball': '4球目で自分が失点',
+          'true-follow_ball': '6球目で自分が得点',
+          'false-follow_ball': '6球目で自分が失点',
+          'true-rally': '7球目以降で得点',
+          'false-rally': '7球目以降で失点'
+        }
+      : {
+          'true-attack_ball': '3球目で自分が得点',
+          'false-attack_ball': '3球目ミスで失点',
+          'true-follow_ball': '5球目で自分が得点',
+          'false-follow_ball': '5球目ミスで失点',
+          'true-rally': '7球目以降で得点',
+          'false-rally': '7球目以降で失点'
+        }
+    this.stepResultTarget.querySelectorAll('[data-decided-at]').forEach(btn => {
+      const key = `${btn.dataset.won}-${btn.dataset.decidedAt}`
+      if (labels[key]) btn.textContent = labels[key]
+    })
   }
 
   updateScore() {

--- a/app/javascript/controllers/serve_receive_input_controller.js
+++ b/app/javascript/controllers/serve_receive_input_controller.js
@@ -1,0 +1,362 @@
+import { Controller } from "@hotwired/stimulus"
+
+const BATTING_STYLE_NAMES = {
+  serve: 'サーブ',
+  receive: 'レシーブ',
+  fore_drive_vs_topspin: '対上回転フォアドライブ',
+  back_drive_vs_topspin: '対上回転バックドライブ',
+  fore_drive_vs_backspin: '対下回転フォアドライブ',
+  back_drive_vs_backspin: '対下回転バックドライブ',
+  fore_push: 'フォアツッツキ',
+  back_push: 'バックツッツキ',
+  fore_stop: 'フォアストップ',
+  back_stop: 'バックストップ',
+  fore_flick: 'フォアフリック',
+  back_flick: 'バックフリック',
+  chiquita: 'チキータ',
+  fore_block: 'フォアブロック',
+  back_block: 'バックブロック',
+  fore_counter: 'フォアカウンター',
+  back_counter: 'バックカウンター',
+  fore_smash: 'フォアスマッシュ',
+  back_smash: 'バックスマッシュ',
+  net_or_edge: 'ネットorエッジ'
+}
+
+const ATTACK_STYLES = Object.keys(BATTING_STYLE_NAMES).filter(s => s !== 'serve' && s !== 'receive')
+
+const SERVE_LENGTHS = { long: 'ロング', half_long: 'ハーフロング', short: 'ショート' }
+
+const SERVE_SPIN_NAMES = { 0: '下回転', 1: '上回転', 2: 'ナックル', 3: '順横回転', 4: '逆横回転' }
+
+const DECIDED_AT_LABELS = { attack_ball: '攻撃', follow_ball: '続球', rally: 'ラリー' }
+
+export default class extends Controller {
+  static targets = [
+    "serverSelect", "serverIndicator", "firstServerField",
+    "currentScore", "originIndicator",
+    "stepServeLength", "stepServeSpins", "stepServeAttack",
+    "stepReceiveStyle", "stepReceiveAttack", "stepResult",
+    "serveAttackButtons", "receiveStyleButtons", "receiveAttackButtons",
+    "patternList", "serialized", "endGameBtn"
+  ]
+
+  static values = {
+    initialFirstServer: String
+  }
+
+  connect() {
+    this.patterns = []
+    this.firstServer = null
+    this.currentStep = null
+
+    // 現在入力中のパターン (ステップ途中の状態)
+    this.draft = {}
+    this.selectedSpins = []
+
+    if (this.hasInitialFirstServerValue && this.initialFirstServerValue) {
+      this.firstServer = this.initialFirstServerValue
+    }
+
+    this.renderAttackButtons()
+    this.renderPatternList()
+    this.updateScore()
+    this.updateEndGameButton()
+    this.serializePatterns()
+    this.updateServerUI()
+  }
+
+  // ========== サーバー選択 ==========
+
+  selectServer(event) {
+    this.firstServer = event.currentTarget.dataset.server
+    this.updateServerUI()
+    this.showStep('origin')
+    this.serializePatterns()
+  }
+
+  updateServerUI() {
+    const hasServer = !!this.firstServer
+    if (this.hasServerSelectTarget) {
+      this.serverSelectTarget.classList.toggle('d-none', hasServer)
+    }
+    if (this.hasServerIndicatorTarget) {
+      this.serverIndicatorTarget.classList.toggle('d-none', !hasServer)
+      this.serverIndicatorTarget.textContent = this.getServerLabel()
+    }
+  }
+
+  getServerLabel() {
+    const current = this.getCurrentServer()
+    if (!current) return ''
+    return current === 'player' ? '🏓 自分のサーブ中' : '🏓 相手のサーブ中'
+  }
+
+  getCurrentServer() {
+    if (!this.firstServer) return null
+    const total = this.patterns.length
+    let isFirstServerTurn
+    if (total < 20) {
+      isFirstServerTurn = Math.floor(total / 2) % 2 === 0
+    } else {
+      isFirstServerTurn = total % 2 === 0
+    }
+    return isFirstServerTurn ? this.firstServer : (this.firstServer === 'player' ? 'opponent' : 'player')
+  }
+
+  // ========== ステップ表示制御 ==========
+
+  showStep(step) {
+    this.currentStep = step
+    const allSteps = [
+      'stepServeLength', 'stepServeSpins', 'stepServeAttack',
+      'stepReceiveStyle', 'stepReceiveAttack', 'stepResult'
+    ]
+    allSteps.forEach(s => {
+      if (this[`has${s.charAt(0).toUpperCase() + s.slice(1)}Target`]) {
+        this[`${s}Target`].classList.add('d-none')
+      }
+    })
+
+    if (step === 'origin') {
+      const origin = this.getOrigin()
+      this.draft.origin = origin
+      if (this.hasOriginIndicatorTarget) {
+        this.originIndicatorTarget.textContent = origin === 'serve' ? '自分のサーブ' : '相手のサーブ（レシーブ）'
+        this.originIndicatorTarget.classList.remove('d-none')
+      }
+      if (origin === 'serve') {
+        if (this.hasStepServeLengthTarget) this.stepServeLengthTarget.classList.remove('d-none')
+      } else {
+        if (this.hasStepReceiveStyleTarget) this.stepReceiveStyleTarget.classList.remove('d-none')
+      }
+    } else if (step === 'spins') {
+      this.selectedSpins = []
+      this.updateSpinButtons()
+      if (this.hasStepServeSpinsTarget) this.stepServeSpinsTarget.classList.remove('d-none')
+    } else if (step === 'serve_attack') {
+      if (this.hasStepServeAttackTarget) this.stepServeAttackTarget.classList.remove('d-none')
+    } else if (step === 'receive_attack') {
+      if (this.hasStepReceiveAttackTarget) this.stepReceiveAttackTarget.classList.remove('d-none')
+    } else if (step === 'result') {
+      if (this.hasStepResultTarget) this.stepResultTarget.classList.remove('d-none')
+    }
+  }
+
+  getOrigin() {
+    const current = this.getCurrentServer()
+    return current === 'player' ? 'serve' : 'receive'
+  }
+
+  // ========== 各ステップの入力 ==========
+
+  selectServeLength(event) {
+    this.draft.serve_length = event.currentTarget.dataset.length
+    this.showStep('spins')
+  }
+
+  toggleSpin(event) {
+    const spin = parseInt(event.currentTarget.dataset.spin)
+    const idx = this.selectedSpins.indexOf(spin)
+    if (idx === -1) {
+      this.selectedSpins.push(spin)
+    } else {
+      this.selectedSpins.splice(idx, 1)
+    }
+    this.updateSpinButtons()
+  }
+
+  updateSpinButtons() {
+    if (!this.hasStepServeSpinsTarget) return
+    const buttons = this.stepServeSpinsTarget.querySelectorAll('[data-spin]')
+    buttons.forEach(btn => {
+      const spin = parseInt(btn.dataset.spin)
+      btn.classList.toggle('active', this.selectedSpins.includes(spin))
+    })
+  }
+
+  confirmSpins() {
+    this.draft.serve_spins = [...this.selectedSpins]
+    this.showStep('serve_attack')
+  }
+
+  selectServeAttack(event) {
+    this.draft.attack_style = event.currentTarget.dataset.style
+    this.showStep('result')
+  }
+
+  selectReceiveStyle(event) {
+    this.draft.receive_style = event.currentTarget.dataset.style
+    this.showStep('receive_attack')
+  }
+
+  selectReceiveAttack(event) {
+    this.draft.attack_style = event.currentTarget.dataset.style
+    this.showStep('result')
+  }
+
+  selectResult(event) {
+    const won = event.currentTarget.dataset.won === 'true'
+    const decidedAt = event.currentTarget.dataset.decidedAt
+
+    const pattern = {
+      origin: this.draft.origin,
+      serve_length: this.draft.serve_length || null,
+      serve_spins: this.draft.serve_spins || [],
+      receive_style: this.draft.receive_style || null,
+      attack_style: this.draft.attack_style,
+      decided_at: decidedAt,
+      won: won
+    }
+
+    this.patterns.push(pattern)
+    this.draft = {}
+    this.selectedSpins = []
+
+    // すべてのステップを隠す
+    this.showStep('origin')
+    // origin step は即座に次の状態に進む（サーバーに従って自動）
+
+    this.renderPatternList()
+    this.updateScore()
+    this.updateEndGameButton()
+    this.serializePatterns()
+    this.dispatchScoreUpdated()
+  }
+
+  // ========== undo ==========
+
+  undo() {
+    // まだ pattern が確定していない途中状態を1つ前に戻す
+    if (this.currentStep === 'origin' || this.currentStep === null) {
+      // パターンが1件以上あれば最後を取り消す
+      if (this.patterns.length === 0) return
+      this.patterns.pop()
+      this.draft = {}
+      this.selectedSpins = []
+      this.renderPatternList()
+      this.updateScore()
+      this.updateEndGameButton()
+      this.serializePatterns()
+      this.dispatchScoreUpdated()
+      this.showStep('origin')
+    } else if (this.currentStep === 'spins') {
+      this.draft.serve_length = null
+      this.showStep('origin')
+    } else if (this.currentStep === 'serve_attack') {
+      this.showStep('spins')
+    } else if (this.currentStep === 'receive_attack') {
+      this.draft.receive_style = null
+      this.showStep('origin')
+    } else if (this.currentStep === 'result') {
+      if (this.draft.origin === 'serve') {
+        this.showStep('serve_attack')
+      } else {
+        this.showStep('receive_attack')
+      }
+    }
+  }
+
+  // ========== レンダリング ==========
+
+  renderAttackButtons() {
+    const html = ATTACK_STYLES.map(style => {
+      const name = BATTING_STYLE_NAMES[style] || style
+      return `<button type="button" class="btn rally-style-btn"
+        data-action="click->serve-receive-input#selectServeAttack"
+        data-style="${style}">${name}</button>`
+    }).join('')
+
+    if (this.hasServeAttackButtonsTarget) this.serveAttackButtonsTarget.innerHTML = html
+
+    const receiveHtml = ATTACK_STYLES.map(style => {
+      const name = BATTING_STYLE_NAMES[style] || style
+      return `<button type="button" class="btn rally-style-btn"
+        data-action="click->serve-receive-input#selectReceiveStyle"
+        data-style="${style}">${name}</button>`
+    }).join('')
+
+    if (this.hasReceiveStyleButtonsTarget) this.receiveStyleButtonsTarget.innerHTML = receiveHtml
+
+    const receiveAttackHtml = ATTACK_STYLES.map(style => {
+      const name = BATTING_STYLE_NAMES[style] || style
+      return `<button type="button" class="btn rally-style-btn"
+        data-action="click->serve-receive-input#selectReceiveAttack"
+        data-style="${style}">${name}</button>`
+    }).join('')
+
+    if (this.hasReceiveAttackButtonsTarget) this.receiveAttackButtonsTarget.innerHTML = receiveAttackHtml
+  }
+
+  renderPatternList() {
+    if (!this.hasPatternListTarget) return
+    if (this.patterns.length === 0) {
+      this.patternListTarget.innerHTML = '<div class="rally-list-empty">まだパターンが入力されていません</div>'
+      return
+    }
+
+    const items = [...this.patterns].reverse().map((p, revIdx) => {
+      const idx = this.patterns.length - revIdx
+      const wonLabel = p.won ? '自分の得点' : '相手の得点'
+      const wonClass = p.won ? 'rally-item-player' : 'rally-item-opponent'
+      const originLabel = p.origin === 'serve' ? 'サーブ' : 'レシーブ'
+      const lengthLabel = p.serve_length ? (SERVE_LENGTHS[p.serve_length] || p.serve_length) : ''
+      const spinsLabel = (p.serve_spins || []).map(s => SERVE_SPIN_NAMES[s] || s).join('/')
+      const attackLabel = BATTING_STYLE_NAMES[p.attack_style] || p.attack_style
+      const decidedLabel = DECIDED_AT_LABELS[p.decided_at] || p.decided_at
+      const detail = p.origin === 'serve'
+        ? `${originLabel}(${lengthLabel} ${spinsLabel}) → ${attackLabel} [${decidedLabel}]`
+        : `${originLabel} → ${attackLabel} [${decidedLabel}]`
+      const isFirst = revIdx === 0
+      return `<div class="rally-item ${wonClass}">
+        <span class="rally-item-seq">${idx}本目</span>
+        <span class="rally-item-detail">${wonLabel} ← ${detail}</span>
+        ${isFirst ? '<button type="button" class="btn btn-sm rally-undo-btn" data-action="click->serve-receive-input#undo">↩ 取り消し</button>' : ''}
+      </div>`
+    }).join('')
+
+    this.patternListTarget.innerHTML = items
+  }
+
+  updateScore() {
+    const playerScore = this.patterns.filter(p => p.won).length
+    const opponentScore = this.patterns.filter(p => !p.won).length
+
+    if (this.hasCurrentScoreTarget) {
+      this.currentScoreTarget.textContent = `${playerScore} - ${opponentScore}`
+    }
+
+    this.updateServerUI()
+  }
+
+  updateEndGameButton() {
+    if (!this.hasEndGameBtnTarget) return
+    if (!this.firstServer) {
+      this.endGameBtnTarget.disabled = true
+      return
+    }
+    const playerScore = this.patterns.filter(p => p.won).length
+    const opponentScore = this.patterns.filter(p => !p.won).length
+    const canEnd = Math.max(playerScore, opponentScore) >= 11 &&
+                   Math.abs(playerScore - opponentScore) >= 2
+    this.endGameBtnTarget.disabled = !canEnd
+  }
+
+  serializePatterns() {
+    if (this.hasSerializedTarget) {
+      this.serializedTarget.value = JSON.stringify(this.patterns)
+    }
+    if (this.hasFirstServerFieldTarget) {
+      this.firstServerFieldTarget.value = this.firstServer || ''
+    }
+  }
+
+  dispatchScoreUpdated() {
+    const playerScore = this.patterns.filter(p => p.won).length
+    const opponentScore = this.patterns.filter(p => !p.won).length
+    this.element.dispatchEvent(new CustomEvent('rally:scoreUpdated', {
+      bubbles: true,
+      detail: { playerScore, opponentScore }
+    }))
+  }
+}

--- a/app/models/serve_receive_pattern.rb
+++ b/app/models/serve_receive_pattern.rb
@@ -15,7 +15,10 @@ class ServeReceivePattern < ApplicationRecord
     back_block: 12, fore_counter: 13,
     back_counter: 14,
     fore_smash: 19, back_smash: 20,
-    net_or_edge: 21
+    net_or_edge: 21,
+    service_ace: 22,
+    receive_ace: 23,
+    receive_miss: 24
   }, prefix: :attack
 
   # receive_style は attack_style と同一のキー・整数マッピングを持つため enum 定義は行わない。

--- a/app/views/match_infos/_serve_receive_form.html.erb
+++ b/app/views/match_infos/_serve_receive_form.html.erb
@@ -1,0 +1,101 @@
+
+<div class="form-container fade-in-up">
+  <%
+    last_game = saved_games.last
+    initial_first_server = if last_game&.first_server
+                             last_game.first_server == 'player' ? 'opponent' : 'player'
+                           end
+  %>
+  <%= form_with(model: match_info, url: create_serve_receive_match_infos_path, method: :post,
+      data: { controller: "scoreboard serve-receive-input",
+              "serve-receive-input-initial-first-server-value": initial_first_server.to_s }) do |form| %>
+
+    <%= hidden_field_tag :draft_id, draft_id if draft_id.present? %>
+
+    <%= render 'shared/error_messages', object: @match_info %>
+
+    <div class="row mb-3">
+      <div class="column">
+        <%= form.label :match_date, "🗓️日付" %>
+        <%= form.date_field :match_date, class: "form-control rounded-pill shadow-sm" %>
+      </div>
+
+      <div class="column">
+        <%= form.label :match_name, "🏆大会名" %>
+        <%= form.text_field :match_name, class: "form-control rounded-pill shadow-sm",
+            placeholder: "出場した大会名を入力" %>
+      </div>
+    </div>
+
+    <% if draft_id.nil? %>
+      <div class="row mb-3">
+        <div class="column">
+          <%= form.label :match_format, "🎮試合形式（ゲームマッチ数）" %>
+          <%= form.select :match_format, [[3, 3], [5, 5], [7, 7]],
+              { selected: 5 },
+              class: "form-select",
+              data: { action: "change->scoreboard#changeFormat" } %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="row mb-3">
+      <div class="column">
+        <%= form.label :player_name, "👤選手名" %>
+        <%= form.text_field :player_name,
+            class: "form-control rounded-pill shadow-sm",
+            placeholder: "分析する選手名を入力",
+            data: { scoreboard_target: "playerNameInput", action: "input->scoreboard#updateNames" } %>
+      </div>
+
+      <div class="column">
+        <%= form.label :opponent_name, "👤対戦相手名" %>
+        <%= form.text_field :opponent_name,
+            class: "form-control rounded-pill shadow-sm",
+            placeholder: "対戦相手の名前を入力",
+            data: { scoreboard_target: "opponentNameInput", action: "input->scoreboard#updateNames" } %>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :memo, "🗒️メモ" %>
+      <%= form.text_area :memo, class: "wide-textarea form-control rounded-pill shadow-sm",
+          placeholder: "対戦相手の戦型や使用用具、分析していて気になったプレーなどを入力" %>
+    </div>
+
+    <div class="analysis-header mb-4 p-3 rounded">
+      <h3 class="text-center">サーブ・レシーブ入力</h3>
+      <div>
+        試合動画を見ながら、1本ずつサーブ・レシーブの内容と結果を入力してください。<br>
+        サーブの長さ・回転・3球目技術、レシーブ技術・4球目技術と結果を記録します。
+      </div>
+    </div>
+
+    <%= render 'match_infos/scoreboard', saved_games: saved_games, max_games: max_games %>
+
+    <%= render 'match_infos/serve_receive_input' %>
+
+    <input type="hidden" name="patterns" data-serve-receive-input-target="serialized" value="">
+    <input type="hidden" name="first_server" data-serve-receive-input-target="firstServerField" value="">
+
+    <div class="center-text">
+      <% if current_game_number <= max_games %>
+        <%= form.submit "#{current_game_number}ゲーム目終了",
+            formaction: end_game_serve_receive_match_infos_path,
+            class: "btn btn-secondary px-4 py-2 mt-4 me-2 rounded-pill shadow",
+            data: { "serve-receive-input-target": "endGameBtn" } %>
+      <% end %>
+      <%= form.submit "🚀 試合を分析する",
+          class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow" %>
+    </div>
+
+    <% if draft_id.present? && saved_games.any? %>
+      <div class="center-text mt-3">
+        <%= link_to "↩ 前のゲームに戻る",
+            undo_game_match_infos_path(draft_id: draft_id),
+            data: { turbo_method: "delete" },
+            class: "btn btn-outline-warning" %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/match_infos/_serve_receive_input.html.erb
+++ b/app/views/match_infos/_serve_receive_input.html.erb
@@ -79,7 +79,7 @@
 
   <%# 3球目技術選択（origin=serve のとき） %>
   <div class="rally-step d-none" data-serve-receive-input-target="stepServeAttack">
-    <div class="rally-step-title mb-2">3球目は？（決まった技術）</div>
+    <div class="rally-step-title mb-2">3球目は？</div>
     <div class="rally-style-buttons" data-serve-receive-input-target="serveAttackButtons">
       <%# JS で動的に描画 %>
     </div>
@@ -103,7 +103,7 @@
 
   <%# 4球目技術選択（origin=receive のとき） %>
   <div class="rally-step d-none" data-serve-receive-input-target="stepReceiveAttack">
-    <div class="rally-step-title mb-2">4球目は？（決まった技術）</div>
+    <div class="rally-step-title mb-2">4球目は？</div>
     <div class="rally-style-buttons" data-serve-receive-input-target="receiveAttackButtons">
       <%# JS で動的に描画 %>
     </div>
@@ -113,39 +113,39 @@
     </div>
   </div>
 
-  <%# 結果6ボタン %>
+  <%# 結果6ボタン — 2列3行 %>
   <div class="rally-step d-none" data-serve-receive-input-target="stepResult">
     <div class="rally-step-title mb-2">結果は？</div>
-    <div class="rally-winner-buttons">
+    <div class="rally-result-buttons">
       <button type="button" class="btn rally-winner-btn rally-winner-player"
               data-action="click->serve-receive-input#selectResult"
               data-won="true" data-decided-at="attack_ball">
-        自分が得点（攻撃）
-      </button>
-      <button type="button" class="btn rally-winner-btn rally-winner-player"
-              data-action="click->serve-receive-input#selectResult"
-              data-won="true" data-decided-at="follow_ball">
-        自分が得点（続球）
-      </button>
-      <button type="button" class="btn rally-winner-btn rally-winner-player"
-              data-action="click->serve-receive-input#selectResult"
-              data-won="true" data-decided-at="rally">
-        自分が得点（ラリー）
+        3球目で自分が得点
       </button>
       <button type="button" class="btn rally-winner-btn rally-winner-opponent"
               data-action="click->serve-receive-input#selectResult"
               data-won="false" data-decided-at="attack_ball">
-        相手が得点（攻撃）
+        3球目ミスで失点
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="true" data-decided-at="follow_ball">
+        5球目で自分が得点
       </button>
       <button type="button" class="btn rally-winner-btn rally-winner-opponent"
               data-action="click->serve-receive-input#selectResult"
               data-won="false" data-decided-at="follow_ball">
-        相手が得点（続球）
+        5球目ミスで失点
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="true" data-decided-at="rally">
+        7球目以降で得点
       </button>
       <button type="button" class="btn rally-winner-btn rally-winner-opponent"
               data-action="click->serve-receive-input#selectResult"
               data-won="false" data-decided-at="rally">
-        相手が得点（ラリー）
+        7球目以降で失点
       </button>
     </div>
     <div class="mt-2">

--- a/app/views/match_infos/_serve_receive_input.html.erb
+++ b/app/views/match_infos/_serve_receive_input.html.erb
@@ -1,0 +1,165 @@
+<div class="rally-input-container" data-controller="serve-receive-input">
+
+  <%# サーブ権選択エリア %>
+  <div class="rally-server-select-area" data-serve-receive-input-target="serverSelect">
+    <div class="rally-server-select-title mb-3">🏓誰からサーブ？</div>
+    <div class="rally-server-buttons">
+      <button type="button" class="btn rally-server-btn rally-server-player"
+              data-action="click->serve-receive-input#selectServer"
+              data-server="player">
+        自分からサーブ
+      </button>
+      <button type="button" class="btn rally-server-btn rally-server-opponent"
+              data-action="click->serve-receive-input#selectServer"
+              data-server="opponent">
+        相手からサーブ
+      </button>
+    </div>
+  </div>
+
+  <%# サーバーインジケーター（サーブ選択後に表示） %>
+  <div class="rally-server-indicator d-none" data-serve-receive-input-target="serverIndicator"></div>
+
+  <%# 現在のスコア表示 %>
+  <div class="rally-current-score mb-3">
+    <span class="rally-score-label">現在のスコア：</span>
+    <span class="rally-score-value" data-serve-receive-input-target="currentScore">0 - 0</span>
+  </div>
+
+  <%# origin 表示エリア（自動判定） %>
+  <div class="d-none" data-serve-receive-input-target="originIndicator"></div>
+
+  <%# サーブ長さ選択（origin=serve のとき表示） %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepServeLength">
+    <div class="rally-step-title mb-2">サーブの長さは？</div>
+    <div class="rally-winner-buttons">
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#selectServeLength"
+              data-length="long">ロング</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#selectServeLength"
+              data-length="half_long">ハーフロング</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#selectServeLength"
+              data-length="short">ショート</button>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# 回転選択（複数選択可） %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepServeSpins">
+    <div class="rally-step-title mb-2">サーブの回転は？（複数選択可）</div>
+    <div class="rally-style-buttons">
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#toggleSpin"
+              data-spin="0">下回転</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#toggleSpin"
+              data-spin="1">上回転</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#toggleSpin"
+              data-spin="2">ナックル</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#toggleSpin"
+              data-spin="3">順横回転</button>
+      <button type="button" class="btn rally-style-btn"
+              data-action="click->serve-receive-input#toggleSpin"
+              data-spin="4">逆横回転</button>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn btn-primary"
+              data-action="click->serve-receive-input#confirmSpins">次へ →</button>
+      <button type="button" class="btn rally-cancel-btn ms-2"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# 3球目技術選択（origin=serve のとき） %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepServeAttack">
+    <div class="rally-step-title mb-2">3球目は？（決まった技術）</div>
+    <div class="rally-style-buttons" data-serve-receive-input-target="serveAttackButtons">
+      <%# JS で動的に描画 %>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# レシーブ技術選択（origin=receive のとき） %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepReceiveStyle">
+    <div class="rally-step-title mb-2">レシーブの技術は？</div>
+    <div class="rally-style-buttons" data-serve-receive-input-target="receiveStyleButtons">
+      <%# JS で動的に描画 %>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# 4球目技術選択（origin=receive のとき） %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepReceiveAttack">
+    <div class="rally-step-title mb-2">4球目は？（決まった技術）</div>
+    <div class="rally-style-buttons" data-serve-receive-input-target="receiveAttackButtons">
+      <%# JS で動的に描画 %>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# 結果6ボタン %>
+  <div class="rally-step d-none" data-serve-receive-input-target="stepResult">
+    <div class="rally-step-title mb-2">結果は？</div>
+    <div class="rally-winner-buttons">
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="true" data-decided-at="attack_ball">
+        自分が得点（攻撃）
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="true" data-decided-at="follow_ball">
+        自分が得点（続球）
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-player"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="true" data-decided-at="rally">
+        自分が得点（ラリー）
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-opponent"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="false" data-decided-at="attack_ball">
+        相手が得点（攻撃）
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-opponent"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="false" data-decided-at="follow_ball">
+        相手が得点（続球）
+      </button>
+      <button type="button" class="btn rally-winner-btn rally-winner-opponent"
+              data-action="click->serve-receive-input#selectResult"
+              data-won="false" data-decided-at="rally">
+        相手が得点（ラリー）
+      </button>
+    </div>
+    <div class="mt-2">
+      <button type="button" class="btn rally-cancel-btn"
+              data-action="click->serve-receive-input#undo">← 戻る</button>
+    </div>
+  </div>
+
+  <%# 入力済みパターン一覧 %>
+  <div class="rally-list-section mt-3">
+    <div class="rally-list-header">入力済みパターン</div>
+    <div class="rally-list" data-serve-receive-input-target="patternList">
+      <div class="rally-list-empty">まだパターンが入力されていません</div>
+    </div>
+  </div>
+
+</div>

--- a/app/views/match_infos/index.html.erb
+++ b/app/views/match_infos/index.html.erb
@@ -1,8 +1,8 @@
 <h1 class="center-text">📝 試合分析一覧</h1>
 
 <div class="d-flex justify-content-center gap-2 mb-3">
-  <%= link_to "試合分析を開始", new_match_info_path, class: "btn btn-success" %>
   <%= link_to "サーブ・レシーブ分析を開始", new_serve_receive_match_infos_path, class: "btn btn-primary" %>
+  <%= link_to "技術別得点率分析を開始", new_match_info_path, class: "btn btn-success" %>
 </div>
 
 <div data-controller="auto-save" data-auto-save-page-value="index"

--- a/app/views/match_infos/index.html.erb
+++ b/app/views/match_infos/index.html.erb
@@ -1,6 +1,9 @@
 <h1 class="center-text">📝 試合分析一覧</h1>
 
-<%= link_to "試合分析を開始", new_match_info_path, class: "btn btn-success btn-center-below-h1" %>
+<div class="d-flex justify-content-center gap-2 mb-3">
+  <%= link_to "試合分析を開始", new_match_info_path, class: "btn btn-success" %>
+  <%= link_to "サーブ・レシーブ分析を開始", new_serve_receive_match_infos_path, class: "btn btn-primary" %>
+</div>
 
 <div data-controller="auto-save" data-auto-save-page-value="index"
      data-auto-save-restore-autosave-url-value="<%= restore_autosave_match_infos_path %>">

--- a/app/views/match_infos/new_serve_receive.html.erb
+++ b/app/views/match_infos/new_serve_receive.html.erb
@@ -1,0 +1,14 @@
+<h1 class="center-text">📝 サーブ・レシーブ分析フォーム</h1>
+
+<%= render "serve_receive_form",
+    match_info: @match_info,
+    draft_id: @draft_id,
+    current_game_number: @current_game_number || 1,
+    saved_games: @saved_games || [],
+    max_games: @max_games || 5 %>
+
+<br>
+
+<div class="center-link mb-5">
+  <%= link_to "← 分析一覧ページへ戻る", match_infos_path %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -54,6 +54,10 @@ ja:
           no_spin: ナックル
           pro_sidespin: 順横回転
           anti_sidespin: 逆横回転
+        attack_style:
+          service_ace: サービスエース
+          receive_ace: レシーブエース
+          receive_miss: レシーブミス
   defaults:
     password_reset: "パスワードリセットのご案内"
   notices:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
       delete :undo_game
       post :interrupt
       post :restore_autosave
+      get  :new_serve_receive
+      post :create_serve_receive
+      post :end_game_serve_receive
     end
   end
 

--- a/plans/77-phase-0-77-1-replicated-twilight-agen-eventual-umbrella.md
+++ b/plans/77-phase-0-77-1-replicated-twilight-agen-eventual-umbrella.md
@@ -1,0 +1,237 @@
+# Sprint 2 UI修正プラン
+
+## Context
+
+Sprint 2で実装したサーブ・レシーブ分析フローのUX改善。ボタンラベル・配置の修正、回転選択の排他制御、サービスエース／レシーブエースの追加が目的。
+
+---
+
+## 変更内容と実装詳細
+
+### 1. 試合分析一覧ページのボタン変更・位置入れ替え
+
+**対象ファイル**: `app/views/match_infos/index.html.erb`（3〜6行目）
+
+- 「試合分析を開始」→「技術別得点率分析を開始」に変更
+- 順序を入れ替え：左に「サーブ・レシーブ分析を開始」、右に「技術別得点率分析を開始」
+
+```erb
+<div class="d-flex justify-content-center gap-2 mb-3">
+  <%= link_to "サーブ・レシーブ分析を開始", new_serve_receive_match_infos_path, class: "btn btn-primary" %>
+  <%= link_to "技術別得点率分析を開始", new_match_info_path, class: "btn btn-success" %>
+</div>
+```
+
+---
+
+### 2. 回転選択の排他制御
+
+**対象ファイル**: `app/javascript/controllers/serve_receive_input_controller.js`
+
+`toggleSpin()` メソッドに排他ロジックを追加：
+- 下回転(spin=0) を選択したら 上回転(spin=1) を強制解除
+- 上回転(spin=1) を選択したら 下回転(spin=0) を強制解除
+- 順横回転(spin=3) を選択したら 逆横回転(spin=4) を強制解除
+- 逆横回転(spin=4) を選択したら 順横回転(spin=3) を強制解除
+
+```javascript
+toggleSpin(event) {
+  const spin = parseInt(event.currentTarget.dataset.spin)
+  const idx = this.selectedSpins.indexOf(spin)
+  if (idx === -1) {
+    // 排他制御
+    const exclusions = { 0: 1, 1: 0, 3: 4, 4: 3 }
+    if (exclusions[spin] !== undefined) {
+      this.selectedSpins = this.selectedSpins.filter(s => s !== exclusions[spin])
+    }
+    this.selectedSpins.push(spin)
+  } else {
+    this.selectedSpins.splice(idx, 1)
+  }
+  this.updateSpinButtons()
+}
+```
+
+---
+
+### 3. 回転ボタン選択状態のスタイル改善
+
+**対象ファイル**: `app/assets/stylesheets/match_infos.scss`
+
+`.rally-style-btn` に `.active` 状態のスタイルを追加。ホバー時と同じグリーンが選択時に保持されるようにする：
+
+```scss
+.rally-style-btn {
+  // 既存スタイルはそのまま
+  &:hover, &.active {
+    background: var(--tt-primary);
+    color: #fff;
+    border-color: var(--tt-primary);
+  }
+}
+```
+
+現在の定義（`&:hover` のみ）に `&.active` を追記。
+
+---
+
+### 4. サービスエース・レシーブエースの追加
+
+#### 4-1. モデルに新 enum 値を追加
+
+**対象ファイル**: `app/models/serve_receive_pattern.rb`
+
+`attack_style` enum に2値を追加（既存値は変更なし）：
+
+```ruby
+enum :attack_style, {
+  # ... 既存 ...
+  net_or_edge: 21,
+  service_ace: 22,   # 追加
+  receive_ace: 23    # 追加
+}, prefix: :attack
+```
+
+`RECEIVE_STYLE_VALUES` 定数への追加は不要（receive_ace はサーブ側のパターンに存在しない）。
+
+#### 4-2. JavaScript の定数・ボタン描画を更新
+
+**対象ファイル**: `app/javascript/controllers/serve_receive_input_controller.js`
+
+**定数に追加：**
+```javascript
+const BATTING_STYLE_NAMES = {
+  // ... 既存 ...
+  service_ace: 'サービスエース',
+  receive_ace: 'レシーブエース'
+}
+```
+
+`ATTACK_STYLES` 配列は `serve`/`receive` を除いた全キーを使うため、自動的に新値が含まれる。
+
+**`renderAttackButtons()` を修正：**
+
+3球目ボタン群（`serveAttackButtonsTarget`）の先頭に「サービスエース」ボタンを追加。アクションハンドラーは `selectServiceAce`（通常の `selectServeAttack` とは別）：
+
+```javascript
+// 3球目ボタン（serveAttackButtonsTarget）
+const serviceAceBtn = `<button type="button" class="btn rally-style-btn rally-style-btn--ace"
+  data-action="click->serve-receive-input#selectServiceAce">サービスエース</button>`
+const attackHtml = serviceAceBtn + ATTACK_STYLES
+  .filter(s => s !== 'service_ace' && s !== 'receive_ace')
+  .map(style => `<button ...>...</button>`)
+  .join('')
+
+// 4球目ボタン（receiveAttackButtonsTarget）
+const receiveAceBtn = `<button type="button" class="btn rally-style-btn rally-style-btn--ace"
+  data-action="click->serve-receive-input#selectReceiveAce">レシーブエース</button>`
+const receiveAttackHtml = receiveAceBtn + ATTACK_STYLES
+  .filter(s => s !== 'service_ace' && s !== 'receive_ace')
+  .map(...)
+  .join('')
+```
+
+**新メソッドを追加：**
+
+```javascript
+selectServiceAce() {
+  const pattern = {
+    origin: this.draft.origin,
+    serve_length: this.draft.serve_length || null,
+    serve_spins: this.draft.serve_spins || [],
+    receive_style: null,
+    attack_style: 'service_ace',
+    decided_at: 'attack_ball',
+    won: true
+  }
+  this._commitPattern(pattern)
+}
+
+selectReceiveAce() {
+  const pattern = {
+    origin: this.draft.origin,
+    serve_length: null,
+    serve_spins: [],
+    receive_style: this.draft.receive_style || null,
+    attack_style: 'receive_ace',
+    decided_at: 'attack_ball',
+    won: true
+  }
+  this._commitPattern(pattern)
+}
+
+_commitPattern(pattern) {
+  this.patterns.push(pattern)
+  this.draft = {}
+  this.selectedSpins = []
+  this.showStep('origin')
+  this.renderPatternList()
+  this.updateScore()
+  this.updateEndGameButton()
+  this.serializePatterns()
+  this.dispatchScoreUpdated()
+}
+```
+
+`selectResult()` 内の重複ロジックも `_commitPattern()` を呼ぶようにリファクタ。
+
+#### 4-3. I18n 翻訳を追加
+
+**対象ファイル**: `config/locales/ja.yml`
+
+`attack_style` の翻訳セクションに追加（既存の `decided_at` 翻訳などと同じ階層）：
+
+```yaml
+serve_receive_pattern:
+  attack_style:
+    service_ace: サービスエース
+    receive_ace: レシーブエース
+```
+
+---
+
+### 5. 「（決まった技術）」ラベル削除
+
+**対象ファイル**: `app/views/match_infos/_serve_receive_input.html.erb`
+
+- 82行目: `「3球目は？（決まった技術）」` → `「3球目は？」`
+- 106行目: `「4球目は？（決まった技術）」` → `「4球目は？」`
+
+---
+
+### 6. RSpec テスト更新
+
+**対象ファイル**: `spec/models/serve_receive_pattern_spec.rb`
+
+- `service_ace` と `receive_ace` が `attack_style` enum に含まれることをテスト
+- `allowed_attack_styles` に新値が含まれることを確認
+
+---
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/views/match_infos/index.html.erb` | ボタンラベル変更・順序入れ替え |
+| `app/views/match_infos/_serve_receive_input.html.erb` | 「（決まった技術）」ラベル削除 |
+| `app/javascript/controllers/serve_receive_input_controller.js` | 排他制御、エース選択、_commitPatternリファクタ |
+| `app/assets/stylesheets/match_infos.scss` | `.rally-style-btn.active` スタイル追加 |
+| `app/models/serve_receive_pattern.rb` | `service_ace`・`receive_ace` enum追加 |
+| `config/locales/ja.yml` | 新enum値の翻訳追加 |
+| `spec/models/serve_receive_pattern_spec.rb` | 新enum値のテスト追加 |
+
+マイグレーションは不要（`attack_style` は整数カラムで、Railsのenum定義のみ変更）。
+
+---
+
+## 検証方法
+
+1. `bin/dev` でサーバー起動
+2. 試合分析一覧ページ（`/match_infos`）でボタン表示・順序を確認
+3. サーブ・レシーブ分析フォームで：
+   - 回転選択：下回転選択後に上回転を押したら下回転が外れることを確認
+   - 回転選択：選択済みボタンがグリーンで保持されることを確認
+   - 3球目で「サービスエース」を押したら即座に次のラリーへ進むことを確認
+   - 4球目で「レシーブエース」を押したら即座に次のラリーへ進むことを確認
+   - サービスエース選択後、入力済みパターン一覧に「自分の得点」として表示されることを確認
+4. `bundle exec rspec && bundle exec rubocop --parallel` で全テスト・Lintがパスすることを確認

--- a/plans/77-phase-0-77-1-replicated-twilight-agen-lively-sketch.md
+++ b/plans/77-phase-0-77-1-replicated-twilight-agen-lively-sketch.md
@@ -1,0 +1,186 @@
+# Sprint 2 UI修正プラン（第2弾）
+
+## Context
+
+Sprint 2 実装後の動作確認で発覚した2点の UX 課題を修正する。
+1. レシーブからの4球目選択後に「レシーブミス」の選択肢がなく、相手得点として即時記録できない
+2. 「結果は？」の6ボタンが横1行に並んでいてテキストが読みづらい（縦長ボタン問題）
+
+---
+
+## 変更内容と実装詳細
+
+### 1. 「レシーブミス」ボタンの追加
+
+**概要**: 4球目選択画面（stepReceiveAttack）の先頭に「レシーブミス」ボタンを追加。押したら即座に「相手の得点」として記録し、次のラリーへ進む。`selectServiceAce` / `selectReceiveAce` と同じパターンで実装する。
+
+#### 1-1. モデルに新 enum 値を追加
+
+**対象ファイル**: `app/models/serve_receive_pattern.rb`
+
+```ruby
+enum :attack_style, {
+  # ... 既存 ...
+  service_ace: 22,
+  receive_ace: 23,
+  receive_miss: 24   # 追加
+}, prefix: :attack
+```
+
+#### 1-2. JavaScript 定数・ボタン描画・メソッドを更新
+
+**対象ファイル**: `app/javascript/controllers/serve_receive_input_controller.js`
+
+**BATTING_STYLE_NAMES に追加:**
+```javascript
+receive_miss: 'レシーブミス'
+```
+
+**`renderAttackButtons()` の receiveAttackButtonsTarget 部分を修正:**
+```javascript
+// 先頭にレシーブエース・レシーブミスの2ボタンを追加
+const receiveAceBtn = `<button ... data-action="...#selectReceiveAce">レシーブエース</button>`
+const receiveMissBtn = `<button ... class="btn rally-style-btn rally-style-btn--miss"
+  data-action="click->serve-receive-input#selectReceiveMiss">レシーブミス</button>`
+const receiveAttackHtml = receiveAceBtn + receiveMissBtn + regularStyles.map(...).join('')
+```
+
+**新メソッドを追加:**
+```javascript
+selectReceiveMiss() {
+  this._commitPattern({
+    origin: this.draft.origin,
+    serve_length: null,
+    serve_spins: [],
+    receive_style: this.draft.receive_style || null,
+    attack_style: 'receive_miss',
+    decided_at: 'attack_ball',
+    won: false   // 相手の得点
+  })
+}
+```
+
+#### 1-3. スタイル追加
+
+**対象ファイル**: `app/assets/stylesheets/match_infos.scss`
+
+`.rally-style-btn--miss` クラスを追加（赤系で視覚的に「失点」を表す）:
+```scss
+.rally-style-btn--miss {
+  font-weight: bold;
+  background: #fee2e2;
+  color: #ef4444;
+  border-color: #ef4444;
+
+  &:hover {
+    background: #ef4444;
+    color: #fff;
+    border-color: #ef4444;
+  }
+}
+```
+
+#### 1-4. I18n 翻訳を追加
+
+**対象ファイル**: `config/locales/ja.yml`
+
+```yaml
+attack_style:
+  service_ace: サービスエース
+  receive_ace: レシーブエース
+  receive_miss: レシーブミス   # 追加
+```
+
+#### 1-5. RSpec テスト追加
+
+**対象ファイル**: `spec/models/serve_receive_pattern_spec.rb`
+
+- `receive_miss` が `attack_style` enum に含まれること
+- `receive_miss` が24番として定義されていること
+
+---
+
+### 2. 「結果は？」ボタンのレイアウト変更（6列1行 → 2列3行）
+
+**概要**: 6個の結果ボタンを「決まったタイミング」でペアにして2列3行に並べ替える。合わせてボタンのラベルを分かりやすいテキストに変更する。
+
+**新しいボタン配置:**
+
+| 左（自分の得点） | 右（相手の得点） |
+|----------------|----------------|
+| 3球目で自分が得点 | 3球目ミスで失点 |
+| 5球目で自分が得点 | 5球目ミスで失点 |
+| 7球目以降で得点   | 7球目以降で失点 |
+
+#### 2-1. HTML のボタン順序・ラベルを変更
+
+**対象ファイル**: `app/views/match_infos/_serve_receive_input.html.erb`
+
+現在: 自分得点3つ → 相手得点3つ の順  
+変更後: decided_at でペアにした順（attack → follow → rally の各行で左=won、右=lost）
+
+```erb
+<%# 結果6ボタン — 2列3行 %>
+<div class="rally-step d-none" data-serve-receive-input-target="stepResult">
+  <div class="rally-step-title mb-2">結果は？</div>
+  <div class="rally-result-buttons">
+    <%# 行1: attack_ball %>
+    <button ... data-won="true"  data-decided-at="attack_ball">3球目で自分が得点</button>
+    <button ... data-won="false" data-decided-at="attack_ball">3球目ミスで失点</button>
+    <%# 行2: follow_ball %>
+    <button ... data-won="true"  data-decided-at="follow_ball">5球目で自分が得点</button>
+    <button ... data-won="false" data-decided-at="follow_ball">5球目ミスで失点</button>
+    <%# 行3: rally %>
+    <button ... data-won="true"  data-decided-at="rally">7球目以降で得点</button>
+    <button ... data-won="false" data-decided-at="rally">7球目以降で失点</button>
+  </div>
+  ...
+</div>
+```
+
+#### 2-2. CSS を CSS Grid に変更
+
+**対象ファイル**: `app/assets/stylesheets/match_infos.scss`
+
+`.rally-winner-buttons` を廃止し `.rally-result-buttons` を追加（既存クラス名を変えてもよい）:
+
+```scss
+.rally-result-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;   // 極小画面のみ1列
+  }
+}
+```
+
+`.rally-winner-btn` / `.rally-winner-player` / `.rally-winner-opponent` は既存スタイルを流用（`flex: 1` → `width: 100%` への変更のみ）。
+
+---
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/models/serve_receive_pattern.rb` | `receive_miss: 24` enum 追加 |
+| `app/javascript/controllers/serve_receive_input_controller.js` | `BATTING_STYLE_NAMES` 追加、`renderAttackButtons()` 修正、`selectReceiveMiss()` 追加 |
+| `app/views/match_infos/_serve_receive_input.html.erb` | 結果ボタンの順序・ラベル変更、コンテナクラス変更 |
+| `app/assets/stylesheets/match_infos.scss` | `.rally-result-buttons` (grid 2列) 追加、`.rally-style-btn--miss` 追加 |
+| `config/locales/ja.yml` | `receive_miss` 翻訳追加 |
+| `spec/models/serve_receive_pattern_spec.rb` | `receive_miss` enum テスト追加 |
+
+マイグレーションは不要（整数カラムの enum 定義のみ変更）。
+
+---
+
+## 検証方法
+
+1. `bin/dev` でサーバー起動
+2. サーブ・レシーブ分析フォームで：
+   - レシーブ技術を選択後の4球目画面に「レシーブミス」ボタンが先頭（赤色）に表示されることを確認
+   - 「レシーブミス」を押したら即座に「相手の得点」として入力済みパターン一覧に表示され、次のラリーへ進むことを確認
+   - 「結果は？」画面のボタンが2列3行（攻撃/攻撃失点, 続球/続球失点, ラリー/ラリー失点）で横長に表示されることを確認
+   - サーブ起点・レシーブ起点どちらのフローでも結果画面が2列3行になることを確認
+3. `bundle exec rspec && bundle exec rubocop --parallel` で全テスト・Lintがパスすることを確認

--- a/plans/77-phase-0-77-1-replicated-twilight-agent-a5d6b2b53eeec6eca.md
+++ b/plans/77-phase-0-77-1-replicated-twilight-agent-a5d6b2b53eeec6eca.md
@@ -1,0 +1,244 @@
+# #77 サーブ・レシーブ起点の3球目/4球目パターン分析 実装設計
+
+既存の「技術別得点率」分析とは完全独立した第二の分析機能。
+試合分析一覧(`match_infos#index`)から新規作成し、ゲーム単位でサーブ/レシーブ起点の連鎖を1得点=1レコードで記録、専用の分析ページで集計表示する。
+
+---
+
+## 設計判断（論点への回答）
+
+### 論点2: MatchInfo の扱い → 既存 MatchInfo に相乗り（推奨）
+別モデル化せず、`MatchInfo` に `analysis_type` enum（`technique`=既存 / `serve_receive`=新機能）を追加する。
+
+理由:
+- 試合情報(日付/大会名/選手名)・autocomplete・`find_or_create_players`・ドラフト機構(draft/partial_game_data)・`scoreboard` partial を**そのまま流用**でき、新規作成コードを最小化できる。別モデルにすると Player belongs_to / ransack / autocomplete / pagy を二重実装することになる。
+- `index` は `analysis_type` で表示カードを出し分け（あるいは両方表示しリンク先を分岐）。`show`/`new`/`create`/`end_game`/`interrupt` は `analysis_type` で分岐。
+- 既存試合入力フローには一切手を入れない方針なので、`analysis_type` のデフォルトは `technique`（既存データは全て technique 扱い、後方互換）。
+
+代替案（別モデル ServeReceiveMatch）は選手・autocomplete・index/show の重複コストが大きく不採用。
+
+### 論点1: データモデル → 新テーブル `serve_receive_patterns`、回転は **integer配列(array: true)**
+回転の複数選択の持ち方の判断:
+- 中間テーブル: 既存にその流儀がなく過剰。不採用。
+- jsonb: 既存 `partial_game_data` で jsonb 実績はあるが、集計で配列要素ごとの GROUP/フィルタをやりたいので不向き。
+- **integer配列 (`t.integer :serve_spins, array: true, default: []`)**: PostgreSQL ネイティブ。Rails で `enum` 化はできないが、定数マップ＋スコープで扱える。回転は「下回転/上回転/ナックル/順横回転/逆横回転」の固定5種で、集計時に `unnest`/Ruby側 flatten が容易。**これを採用**。
+  - 補足: 既存 array 列は無いが、Rails標準機能であり流儀違反ではない。`spin` 自体は batting_style とは別概念（enum重複を避ける）なので独自定数で定義。
+
+### 論点の内部表現
+- `origin`: enum `{ serve: 0, receive: 1 }`（その得点が自分のサーブ番かレシーブ番か。`RallyContextBuilder#my_serve?` で自動判定）
+- `serve_length`: enum `{ long: 0, half_long: 1, short: 2 }`（nullable, origin=serve時のみ）
+- `serve_spins`: integer配列（origin=serve時のみ。定数 `SERVE_SPINS = { backspin:0, topspin:1, no_spin:2, pro_sidespin:3, anti_sidespin:4 }`）
+- `receive_style`: integer（batting_style enum 値, nullable, origin=receive時のみ。レシーブの種類）
+- `attack_style`: integer（batting_style enum 値。serve起点=3球目 / receive起点=4球目の技術）
+- `decided_at`: enum `{ attack_ball: 0, follow_ball: 1, rally: 2 }`（3or4球目 / 5or6球目 / サーブ起点:7球目以降/レシーブ起点:8球目以降）
+- `won`: boolean（自分が得点なら true）
+- 結果6種は `decided_at × won` で表現。得点板は won=true→自分+1, won=false→相手+1。
+
+---
+
+## 1. データモデル / マイグレーション
+
+新規migration（schema版 `2026_05_18_052507` より後のタイムスタンプ。例 `20260518060000` 系）。`ActiveRecord::Migration[7.1]` 準拠、`t.references ..., foreign_key: true` + `t.timestamps`、複合index は create_table 外で add_index（`create_rallies.rb` の流儀）。
+
+### migration A: AddAnalysisTypeToMatchInfos
+```
+add_column :match_infos, :analysis_type, :integer, null: false, default: 0
+```
+（0=technique。既存データは自動で technique）
+
+### migration B: CreateServeReceivePatterns
+```
+create_table :serve_receive_patterns do |t|
+  t.references :match_info, null: false, foreign_key: true
+  t.references :game, null: true, foreign_key: true
+  t.integer :game_number, null: false
+  t.integer :sequence_number, null: false
+  t.integer :origin, null: false
+  t.integer :serve_length            # nullable
+  t.integer :serve_spins, array: true, default: []
+  t.integer :receive_style           # nullable (batting_style値)
+  t.integer :attack_style, null: false # batting_style値（3or4球目）
+  t.integer :decided_at, null: false
+  t.boolean :won, null: false
+  t.timestamps
+end
+add_index :serve_receive_patterns, [:match_info_id, :game_number, :sequence_number],
+          unique: true, name: 'index_srp_on_match_info_game_sequence'
+```
+
+---
+
+## 2. モデル
+
+### app/models/match_info.rb（編集・流用）
+- `enum :analysis_type, { technique: 0, serve_receive: 1 }` を追加。
+- `has_many :serve_receive_patterns, dependent: :destroy` を追加。
+- 既存メソッドは無変更。`index`/`show` 分岐用に `serve_receive?` を enum が提供。
+
+### app/models/serve_receive_pattern.rb（新規）
+- `belongs_to :match_info` / `belongs_to :game, optional: true`
+- `enum :origin, { serve: 0, receive: 1 }`
+- `enum :serve_length, { long: 0, half_long: 1, short: 2 }`
+- `enum :decided_at, { attack_ball: 0, follow_ball: 1, rally: 2 }`
+- `enum :attack_style` / `enum :receive_style`: **batting_style と同じ整数マップを共有**。`Score::BATTING_STYLES` のような共通定義を使いたいが、既存は Score/Rally で enum をベタ書き重複している流儀。→ 流儀に合わせ、同じ enum ハッシュを `attack_style`/`receive_style` で再掲（serve/receive含む全マップ、ただし入力UI/集計で `serve` `receive` を除外）。
+- 定数 `SERVE_SPINS = { backspin: 0, topspin: 1, no_spin: 2, pro_sidespin: 3, anti_sidespin: 4 }` と日本語マップ。
+- `validates :origin, :attack_style, :decided_at, :game_number, :sequence_number, presence: true`（won は boolean なので presence 不要、`inclusion: [true,false]`）。
+- `self.allowed_attack_styles` = batting_styles.keys - %w[serve receive]（入力候補20種）。
+
+I18n: `config/locales/ja.yml` に `serve_receive_pattern` の `origin`/`serve_length`/`decided_at`/`serve_spin` の和名を追加。`attack_style`/`receive_style` の和名は既存 `Score.human_enum_name(:batting_style, ...)` を流用（新規作成しない）。
+
+---
+
+## 3. ルーティング
+
+`config/routes.rb` の `resources :match_infos` collection を流用しつつ、新フロー専用アクションを追加。MatchInfo相乗りなので**新リソースは作らない**。
+
+```
+resources :match_infos do
+  collection do
+    get :autocomplete            # 流用（field分岐済み）
+    post :end_game
+    delete :undo_game
+    post :interrupt
+    post :restore_autosave
+    # 新機能
+    get  :new_serve_receive      # 新フロー入口（index ボタンから）
+    post :create_serve_receive
+    post :end_game_serve_receive
+  end
+end
+```
+（最小化のため `analysis_type=serve_receive` を `new`/`create`/`end_game` 内分岐にする案も可。本plan は新アクションで明示分離する方が既存 technique フローへの影響ゼロで安全と判断。show は同一 `show` を analysis_type で分岐。）
+
+---
+
+## 4. コントローラ
+
+`app/controllers/match_infos_controller.rb` に新アクションを追加（既存 private メソッドの **流用** が中心。`find_or_create_players` / `draft_or_new_match_info` / `basic_match_info_params` / `autocomplete` はそのまま）。
+
+- `new_serve_receive`: `setup_new_form` 流用 + `@match_info.analysis_type = :serve_receive`。draft_id 対応も `setup_draft_form` 流用。
+- `create_serve_receive`: `create` を踏襲。`draft_or_new_match_info` で MatchInfo を作り `analysis_type: :serve_receive` を付与、保存後 `create_game_from_patterns` を呼ぶ。
+- `end_game_serve_receive`: 既存 `end_game`→`persist_and_finalize_game` の構造を踏襲し、`create_game_from_patterns` 版を用意。
+- `show`: 既存に `if @match_info.serve_receive?` 分岐を追加し、`@srp_analysis = ServeReceiveAnalyzer.new(@match_info)` をセット（ChatgptService呼び出しはスキップ or 別扱い）。
+
+新規 private（`create_game_from_rallies` 系の鏡像）:
+- `create_game_from_patterns(match_info)`: `params[:patterns]`(JSON) を parse。
+- `create_game_record_from_patterns`: won true/false 集計で `player_score`/`opponent_score`/`first_server` を持つ Game を作る（`create_game_record_from_rallies` と同型）。`first_server` は `params[:first_server]` を流用。
+- `persist_pattern_records`: each_with_index で `match_info.serve_receive_patterns.create!(...)`。
+- `pattern_params`: `JSON.parse(params[:patterns])`。
+
+`my_serve?` ロジックは **JS側で算出した origin を信頼**しつつ、サーバ側でも `RallyContextBuilder#my_serve?` を切り出した共有メソッドで検証/再計算できるようにする（DRYのため `RallyContextBuilder.my_serve?(first_server, sequence_number)` をクラスメソッド化 or ServiceObjectに抽出。最小変更なら既存private を残しつつ新Analyzerに同ロジックをコピーしない方針で共有モジュール `ServeOrderCalculator` を新設）。
+
+---
+
+## 5. View
+
+`app/views/match_infos/` 配下に追加（既存 partial を最大流用）。
+
+- `new_serve_receive.html.erb`（新規, `new.html.erb` の鏡像）: `_serve_receive_form` を render。
+- `_serve_receive_form.html.erb`（新規, `_form.html.erb` を土台に複製改変）:
+  - 試合情報フィールド(date/match_name/match_format/player_name/opponent_name/memo) と autocomplete・`scoreboard` data 属性は **そのままコピー**。
+  - `form_with url: create_serve_receive_match_infos_path`。
+  - `render 'match_infos/scoreboard'` を**流用**（無変更）。
+  - `render 'match_infos/serve_receive_input'`（新規 partial）。
+  - hidden `name="patterns"`（rally_input の serialized 相当）, `name="first_server"`。
+  - submit: 「Nゲーム目終了」→ `end_game_serve_receive_match_infos_path`、「試合を分析する」→ `create_serve_receive`。`interrupt`/autosave は流用 or Sprintで後追い。
+- `_serve_receive_input.html.erb`（新規, `_rally_input.html.erb` を土台）:
+  - サーブ権選択エリア（`_rally_input` の server-select 流用）→ origin 自動判定表示。
+  - origin=serve: サーブ長さ(3ボタン択一) → 回転(5ボタン複数選択トグル) → 3球目技術ボタン群 → 結果6ボタン。
+  - origin=receive: レシーブ技術ボタン群 → 4球目技術ボタン群 → 結果6ボタン。
+  - 入力済み一覧。
+- show 側: `_serve_receive_analysis.html.erb`（新規）で `_batting_score_table` を **theme: :player/:opponent で流用**して各集計テーブルを表示。show.html.erb に `if @match_info.serve_receive?` 分岐追加。
+- index 側: `index.html.erb` に「サーブ・レシーブ分析を開始」ボタン追加（`new_serve_receive_match_infos_path`）。`_match_info_summary` を analysis_type バッジ表示に微修正、リンク先は show 共通。
+
+---
+
+## 6. Stimulus
+
+`app/javascript/controllers/serve_receive_input_controller.js`（新規, `rally_input_controller.js` を土台に状態機械を拡張）。
+
+- 定数: `BATTING_STYLE_NAMES`（既存からコピー）, `SERVE_LENGTHS`, `SERVE_SPINS`, `DECIDED_RESULTS`(6種ラベル)。
+- 状態: `this.patterns=[]`, `this.firstServer`, ステップ管理（`origin → (serveLength→spins[] | receiveStyle) → attackStyle → result`）。
+- origin 自動判定: 既存 `getCurrentServer()` を**そのまま流用**（first_server + patterns.length から算出 → player なら serve, opponent なら receive）。
+- 回転は複数選択: spinボタンを toggle、選択配列を保持、「次へ」で確定。
+- 結果6ボタン押下で1 pattern を push、`{origin, serve_length, serve_spins, receive_style, attack_style, decided_at, won}` を構築。won で得点板加算（`rally:scoreUpdated` イベント発火、`scoreboard_controller` を**無変更で流用**）。
+- `serializePatterns()` → hidden `patterns` にJSON。`firstServerField` 連携も流用。
+- undo/showMore/サーバーインジケータは `rally_input_controller` から流用。
+
+---
+
+## 7. 集計（サービス層）+ ヘルパー
+
+集計はサービス、表示は partial の分離（`RallyContextBuilder` + `_batting_score_table` の流儀）。
+
+`app/services/serve_receive_analyzer.rb`（新規）:
+- `initialize(match_info)` で `match_info.serve_receive_patterns` をロード。
+- 集計メソッド（`_batting_score_table` が期待する `{ batting_style:, score:, lost_score:, share: }` 形に整形）:
+  - `serve_length_stats`（サーブ別 得点/失点）
+  - `serve_pattern_stats`（サーブ長さ＋回転＋3球目 の組合せ別）
+  - `receive_style_stats`（レシーブ別）
+  - `receive_pattern_stats`（レシーブ＋4球目 の組合せ別）
+  - `decided_at_distribution`（決着タイミング分布）
+- `append_share`/share% は `ApplicationHelper` に既にある（`build_aggregated_score_data`/`append_share`）。**集計結果を helper互換ハッシュに合わせれば `_batting_score_table` をそのまま使える**。組合せ別パターンは batting_style キー単独でないため、テーブル表示用に「ラベル文字列」列を持つ簡易 partial を1枚追加するか、`_batting_score_table` の `Score.human_enum_name` 部分をラベル直挿しできるよう小改修。
+
+---
+
+## 8. テスト方針（各Sprintで rspec + rubocop 緑）
+
+- `spec/factories/serve_receive_patterns.rb`（新規, `rallies.rb` factory に倣う）。
+- `spec/models/serve_receive_pattern_spec.rb`: enum/validation/`allowed_attack_styles`/spins配列。
+- `spec/models/match_info_spec.rb`（追記）: analysis_type enum, 関連。
+- `spec/services/serve_receive_analyzer_spec.rb`: 各集計の数値・share%・空データ。
+- `spec/requests/match_infos_spec.rb`（追記）: `new_serve_receive`/`create_serve_receive`/`end_game_serve_receive` の POST、patterns JSON 永続化、得点集計、認可(`current_user.match_infos`)。
+- `spec/system/...`（任意）: 入力フロー（origin→結果6ボタン→保存）。
+- rubocop: `RallyContextBuilder` 同様 `# rubocop:disable Metrics/...` を必要箇所に。
+
+---
+
+## 9. スプリント分割（feature/sprint-N-xxx）
+
+既存リポジトリの `feature/sprint-N-xxx` ＋ PRマージ運用に合わせる。各Sprint末で rspec/rubocop 緑。
+
+### Sprint 1 — feature/sprint-1-serve-receive-model
+- migration A/B（analysis_type, serve_receive_patterns）。
+- `ServeReceivePattern` モデル + `MatchInfo` enum/関連 + I18n。
+- factory + model spec。
+- 入力UI/集計はまだ。`db:migrate` + green。
+- 成果物: スキーマとモデルが揃い、コンソール/specでレコード作成可能。
+
+### Sprint 2 — feature/sprint-2-serve-receive-input
+- ルーティング(new/create/end_game_serve_receive)。
+- コントローラ新アクション + `create_game_from_patterns` 系 private。
+- `new_serve_receive`/`_serve_receive_form`/`_serve_receive_input` View。
+- `serve_receive_input_controller.js`（origin自動判定・サーブ長さ・回転複数選択・攻撃技術・結果6ボタン・得点板連携）。
+- index に開始ボタン。
+- request spec（保存・集計・認可）。
+- 成果物: 入口→入力→保存→（暫定の素朴な show 表示 or リダイレクト）まで通る。
+
+### Sprint 3 — feature/sprint-3-serve-receive-analysis
+- `ServeReceiveAnalyzer` サービス + spec。
+- show 分岐 + `_serve_receive_analysis` partial（`_batting_score_table` 流用＋パターン用ラベル表示）。
+- 5種集計（サーブ別/サーブ→3球目/レシーブ別/レシーブ→4球目/決着タイミング）。
+- 成果物: 専用分析ページ完成。
+
+### Sprint 4（任意・余力）— feature/sprint-4-serve-receive-ux
+- interrupt/undo_game/auto_save の新フロー対応（既存機構流用）。
+- index カードの analysis_type バッジ整備、show の AI連携要否判断。
+- system spec 拡充。
+
+---
+
+## 再利用（新規作成しない）一覧
+- `scoreboard` partial / `scoreboard_controller.js`: 無変更で流用。
+- `auto_save_controller.js`: 流用（Sprint4でフィールド名対応のみ）。
+- `find_or_create_players` / `draft_or_new_match_info` / `basic_match_info_params` / `autocomplete` / `autocomplete_candidates`: 流用。
+- `_batting_score_table.html.erb`（theme: :player/:opponent, 構成比バー）: 流用。
+- `ApplicationHelper`の `append_share` / `build_aggregated_score_data` / `abbreviate_batting_style`: 流用。
+- `Score.human_enum_name(:batting_style, ...)`: 攻撃技術/レシーブ技術の和名に流用（新I18nキー作らない）。
+- `RallyContextBuilder#my_serve?` のロジック: origin自動判定に流用（共有メソッド化）。
+- 入力UIの型（form_with + Stimulus + hidden JSON, 段階UI, server選択）: `_form`/`_rally_input`/`rally_input_controller.js` を土台に複製改変。
+
+## 新規作成
+- migration ×2 / `ServeReceivePattern` モデル / `ServeReceiveAnalyzer` サービス /
+  controller 新アクション群 / `new_serve_receive`・`_serve_receive_form`・`_serve_receive_input`・`_serve_receive_analysis` view /
+  `serve_receive_input_controller.js` / 各 spec / factory / ja.yml 追記 / routes 追記。

--- a/spec/models/serve_receive_pattern_spec.rb
+++ b/spec/models/serve_receive_pattern_spec.rb
@@ -73,6 +73,34 @@ RSpec.describe ServeReceivePattern, type: :model do
       allowed = ServeReceivePattern.allowed_attack_styles
       expect(allowed).to include('fore_drive_vs_topspin', 'fore_drive_vs_backspin')
     end
+
+    it "service_aceが含まれること" do
+      expect(ServeReceivePattern.allowed_attack_styles).to include('service_ace')
+    end
+
+    it "receive_aceが含まれること" do
+      expect(ServeReceivePattern.allowed_attack_styles).to include('receive_ace')
+    end
+  end
+
+  describe "attack_style enum" do
+    it "service_aceが22番として定義されていること" do
+      expect(ServeReceivePattern.attack_styles['service_ace']).to eq(22)
+    end
+
+    it "receive_aceが23番として定義されていること" do
+      expect(ServeReceivePattern.attack_styles['receive_ace']).to eq(23)
+    end
+
+    it "receive_missが24番として定義されていること" do
+      expect(ServeReceivePattern.attack_styles['receive_miss']).to eq(24)
+    end
+  end
+
+  describe ".allowed_attack_styles (receive_miss)" do
+    it "receive_missが含まれること" do
+      expect(ServeReceivePattern.allowed_attack_styles).to include('receive_miss')
+    end
   end
 
   describe "serve_spinsの配列保存" do

--- a/spec/requests/match_infos_spec.rb
+++ b/spec/requests/match_infos_spec.rb
@@ -349,4 +349,95 @@ RSpec.describe "MatchInfos", type: :request do
       expect(response).to redirect_to(match_infos_path)
     end
   end
+
+  describe "GET /match_infos/new_serve_receive" do
+    it "200を返すこと" do
+      get new_serve_receive_match_infos_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "未ログインの場合はリダイレクトされること" do
+      delete logout_path
+      get new_serve_receive_match_infos_path
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe "POST /match_infos/create_serve_receive" do
+    let(:patterns_data) do
+      [
+        { 'origin' => 'serve', 'serve_length' => 'short', 'serve_spins' => [0],
+          'receive_style' => nil, 'attack_style' => 'fore_drive_vs_backspin',
+          'decided_at' => 'attack_ball', 'won' => true },
+        { 'origin' => 'receive', 'serve_length' => nil, 'serve_spins' => [],
+          'receive_style' => 'chiquita', 'attack_style' => 'back_drive_vs_topspin',
+          'decided_at' => 'follow_ball', 'won' => false }
+      ]
+    end
+    let(:params) do
+      {
+        match_info: attributes_for(:match_info).merge(
+          player_name: "選手A",
+          opponent_name: "選手B"
+        ),
+        patterns: patterns_data.to_json,
+        first_server: 'player'
+      }
+    end
+
+    it "ServeReceivePattern レコードが作成されること" do
+      expect do
+        post create_serve_receive_match_infos_path, params: params
+      end.to change(ServeReceivePattern, :count).by(2)
+    end
+
+    it "MatchInfo が analysis_type: serve_receive で作成されること" do
+      post create_serve_receive_match_infos_path, params: params
+      expect(MatchInfo.last.analysis_type).to eq('serve_receive')
+    end
+
+    it "未ログインの場合はリダイレクトされること" do
+      delete logout_path
+      post create_serve_receive_match_infos_path, params: params
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe "POST /match_infos/end_game_serve_receive" do
+    let(:patterns_data) do
+      Array.new(13) do |i|
+        { 'origin' => 'serve', 'serve_length' => 'short', 'serve_spins' => [0],
+          'receive_style' => nil, 'attack_style' => 'fore_drive_vs_backspin',
+          'decided_at' => 'attack_ball', 'won' => i < 11 }
+      end
+    end
+    let(:params) do
+      {
+        match_info: attributes_for(:match_info).merge(
+          player_name: "選手A",
+          opponent_name: "選手B"
+        ),
+        patterns: patterns_data.to_json,
+        first_server: 'player'
+      }
+    end
+
+    it "Game が作成されること" do
+      expect do
+        post end_game_serve_receive_match_infos_path, params: params
+      end.to change(Game, :count).by(1)
+    end
+
+    it "ServeReceivePattern が作成されること" do
+      expect do
+        post end_game_serve_receive_match_infos_path, params: params
+      end.to change(ServeReceivePattern, :count).by(13)
+    end
+
+    it "new_serve_receive フォームへリダイレクトすること" do
+      post end_game_serve_receive_match_infos_path, params: params
+      draft = MatchInfo.last
+      expect(response).to redirect_to(new_serve_receive_match_infos_path(draft_id: draft.id))
+    end
+  end
 end


### PR DESCRIPTION
## 概要

サーブ・レシーブ分析フローを新規実装した。試合中の各ラリーをサーブ起点・レシーブ起点に分類し、サーブの長さ・回転・技術の選択をステップ形式で入力できる専用UIを追加。入力データは `ServeReceivePattern` モデルで保存され、ゲーム終了時に一括保存される。

主な実装内容:
- **専用入力フロー**: サーバー選択 → サーブ長さ → 回転（複数選択）→ 3球目技術 → 結果の順にステップ入力
- **Stimulus コントローラー**: `serve_receive_input_controller.js` でフロー全体を管理（undo機能・スコア連動・シリアライズ含む）
- **スコアボード連動**: 入力のたびにリアルタイムでスコアと得点率を更新
- **入力済みパターン一覧**: 直近の入力を取り消せるundo機能付きで表示
- **自動サーバー交替**: 2本交替ルールに基づきサーバーを自動判定

## UI修正（動作確認後の改善）

- サービスエース・レシーブエース・レシーブミスを即時コミットできるボタンを追加
- 回転選択に排他制御を追加（下回転↔上回転、順横回転↔逆横回転）
- 「結果は？」ボタンをCSS Grid 2列3行に変更し、サーブ/レシーブ起点でラベルを動的切替（3球目/4球目、5球目/6球目）
- 試合分析一覧のボタンラベル・順序を調整

## 確認方法

1. `bin/dev` でサーバーを起動
2. `/match_infos` から「サーブ・レシーブ分析を開始」をクリック
3. 試合情報を入力し、ラリー入力フローを操作:
   - サーバーを選択するとステップ入力が始まること
   - サーブ長さ → 回転 → 3球目技術 → 結果の順に進むこと
   - 結果選択後にスコアと入力済みパターンが更新されること
   - undoボタンで直前のラリーを取り消せること
   - サービスエース・レシーブエース・レシーブミスで即時コミットされること
   - 「結果は？」が2列3行で表示され、レシーブ起点では「4球目/6球目」ラベルになること

## 影響範囲

- サーブ・レシーブ分析フォーム（`new_serve_receive`、`serve_receive_match_infos` ルート）
- 試合分析一覧ページ（`/match_infos`）
- `ServeReceivePattern` モデル（enum追加のみ、マイグレーション不要）

## チェックリスト

- [x] RuboCop をパスした
- [x] RSpec をパスした（21件）
- [x] 動作確認済み（サーブ/レシーブ両起点で検証）

Refs #77 

🤖 Generated with [Claude Code](https://claude.com/claude-code)