### PR TITLE
feat: Sprint 3 — サーブ・レシーブ専用分析ページの実装とUI改善

### DIFF
--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -9,7 +9,9 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
 
   def show
     set_match_info_scores
-    if @match_info.advice.present?
+    if @match_info.serve_receive?
+      @srp_analysis = ServeReceiveAnalyzer.new(@match_info)
+    elsif @match_info.advice.present?
       @advice = @match_info.advice
     else
       advice = ChatgptService.get_advice(@match_info)

--- a/app/controllers/match_infos_controller.rb
+++ b/app/controllers/match_infos_controller.rb
@@ -124,6 +124,13 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
   end
 
   def new_serve_receive
+    if params[:draft_id].present?
+      draft = current_user.match_infos.find_by(id: params[:draft_id])
+      if draft
+        setup_draft_form(draft)
+        return
+      end
+    end
     @match_info = MatchInfo.new
     @match_info.analysis_type = :serve_receive
     @draft_id = nil
@@ -453,21 +460,27 @@ class MatchInfosController < ApplicationController # rubocop:disable Metrics/Cla
 
   def persist_pattern_records(match_info, game, patterns, game_number)
     patterns.each_with_index do |p, i|
-      spins = p['serve_spins']
-      spins = spins.is_a?(Array) ? spins.map(&:to_i) : []
       match_info.serve_receive_patterns.create!(
-        game_id: game.id,
-        game_number: game_number,
-        sequence_number: i + 1,
-        origin: p['origin'],
-        serve_length: p['serve_length'].presence,
-        serve_spins: spins,
-        receive_style: p['receive_style'].presence,
-        attack_style: p['attack_style'],
-        decided_at: p['decided_at'],
-        won: p['won']
+        build_pattern_attrs(game, game_number, i + 1, p)
       )
     end
+  end
+
+  def build_pattern_attrs(game, game_number, seq, pat)
+    spins = pat['serve_spins']
+    spins = spins.is_a?(Array) ? spins.map(&:to_i) : []
+    {
+      game_id: game.id,
+      game_number: game_number,
+      sequence_number: seq,
+      origin: pat['origin'],
+      serve_length: pat['serve_length'].presence,
+      serve_spins: spins,
+      receive_style: ServeReceivePattern::RECEIVE_STYLE_VALUES[pat['receive_style']&.to_sym],
+      attack_style: pat['attack_style'],
+      decided_at: pat['decided_at'],
+      won: pat['won']
+    }
   end
 
   def basic_match_info_params

--- a/app/services/serve_receive_analyzer.rb
+++ b/app/services/serve_receive_analyzer.rb
@@ -1,5 +1,6 @@
 class ServeReceiveAnalyzer
   RECEIVE_STYLE_VALUES_USED = ServeReceivePattern::RECEIVE_STYLE_VALUES
+  RECEIVE_DIRECT_STYLES = %w[receive_ace receive_miss].freeze
 
   def initialize(match_info)
     @patterns = match_info.serve_receive_patterns.to_a
@@ -9,7 +10,7 @@ class ServeReceiveAnalyzer
 
   # ①サーブ長さ別得点率
   def serve_length_stats
-    entries = ServeReceivePattern.serve_lengths.keys.filter_map do |length|
+    entries = ServeReceivePattern.serve_lengths.keys.reverse.filter_map do |length|
       patterns = @serve_patterns.select { |p| p.serve_length == length }
       next if patterns.empty?
 
@@ -28,34 +29,30 @@ class ServeReceiveAnalyzer
     append_share(mapped.sort_by { |s| -s[:score] })
   end
 
-  # ③レシーブ技術別得点率
-  def receive_style_stats
-    entries = RECEIVE_STYLE_VALUES_USED.filter_map do |key, val|
-      patterns = @receive_patterns.select { |p| p.receive_style == val }
-      next if patterns.empty?
-
-      build_stats(label: Score.human_enum_name(:batting_style, key), patterns: patterns)
-    end
-    append_share(entries)
+  # ③レシーブ直接決着率（レシーブエース・ミスで即決した得点/失点を集計）
+  def receive_direct_stats
+    direct = @receive_patterns.select { |p| p.attack_style == 'receive_ace' || p.attack_style == 'receive_miss' }
+    entries = direct.group_by(&:receive_style).filter_map { |s, p| build_direct_entry(s, p) }
+    append_share(entries.sort_by { |s| -s[:score] })
   end
 
   # ④レシーブ（技術+4球目）組み合わせ別
   def receive_pattern_stats
     grouped = @receive_patterns.group_by { |p| [p.receive_style, p.attack_style] }
     mapped = grouped.map do |(recv, attack), patterns|
-      recv_label = recv ? Score.human_enum_name(:batting_style, receive_key(recv)) : '不明'
+      recv_key = recv ? receive_key(recv) : nil
+      recv_label = recv_key ? Score.human_enum_name(:batting_style, recv_key) : '不明'
       attack_label_str = attack_label(attack)
       build_stats(label: "#{recv_label} → #{attack_label_str}", patterns: patterns)
     end
     append_share(mapped.sort_by { |s| -s[:score] })
   end
 
-  # ⑤決着タイミング分布（全体・サーブ/レシーブ別）
+  # ⑤得点タイミング分布（サーブ/レシーブ別）
   def decided_at_distribution
     {
-      all: decided_at_group(@patterns),
-      serve: decided_at_group(@serve_patterns),
-      receive: decided_at_group(@receive_patterns)
+      serve: serve_timing_stats,
+      receive: receive_timing_stats
     }
   end
 
@@ -64,6 +61,35 @@ class ServeReceiveAnalyzer
   end
 
   private
+
+  def serve_timing_stats
+    service_ace_grp = @serve_patterns.select { |p| p.attack_style == 'service_ace' }
+    regular = @serve_patterns.reject { |p| p.attack_style == 'service_ace' }
+    prefix = service_ace_grp.any? ? [build_timing_entry('1球目', service_ace_grp)] : []
+    prefix + timing_entries_for(regular, :serve)
+  end
+
+  def receive_timing_stats
+    direct_grp = @receive_patterns.select { |p| RECEIVE_DIRECT_STYLES.include?(p.attack_style) }
+    regular = @receive_patterns.reject { |p| RECEIVE_DIRECT_STYLES.include?(p.attack_style) }
+    prefix = direct_grp.any? ? [build_timing_entry('2球目', direct_grp)] : []
+    prefix + timing_entries_for(regular, :receive)
+  end
+
+  def timing_entries_for(patterns, origin)
+    scope = "activerecord.attributes.serve_receive_pattern.decided_at_#{origin}"
+    ServeReceivePattern.decided_ats.each_key.map do |key|
+      build_timing_entry(I18n.t("#{scope}.#{key}"), patterns.select { |p| p.decided_at == key })
+    end
+  end
+
+  def build_timing_entry(label, patterns)
+    score = patterns.count(&:won)
+    lost_score = patterns.count { |p| !p.won }
+    total = score + lost_score
+    rate = total.positive? ? (score.to_f / total * 100).round : 0
+    { label: label, score: score, lost_score: lost_score, rate: rate, share: 0 }
+  end
 
   def build_stats(label:, patterns:)
     score      = patterns.count(&:won)
@@ -90,18 +116,20 @@ class ServeReceiveAnalyzer
   end
 
   def attack_label(key)
-    Score.human_enum_name(:batting_style, key)
+    I18n.t("activerecord.attributes.score.batting_style.#{key}",
+           default: I18n.t("activerecord.attributes.serve_receive_pattern.attack_style.#{key}", default: key.to_s))
   end
 
   def receive_key(val)
     ServeReceivePattern::RECEIVE_STYLE_VALUES.key(val)
   end
 
-  def decided_at_group(patterns)
-    ServeReceivePattern.decided_ats.keys.map do |key|
-      grp = patterns.select { |p| p.decided_at == key }
-      label = I18n.t("activerecord.attributes.serve_receive_pattern.decided_at.#{key}")
-      { label: label, score: grp.count(&:won), lost_score: grp.count { |p| !p.won } }
-    end
+  def build_direct_entry(recv_style, patterns)
+    return unless recv_style
+
+    key = receive_key(recv_style)
+    return unless key
+
+    build_stats(label: Score.human_enum_name(:batting_style, key), patterns: patterns)
   end
 end

--- a/app/services/serve_receive_analyzer.rb
+++ b/app/services/serve_receive_analyzer.rb
@@ -1,0 +1,107 @@
+class ServeReceiveAnalyzer
+  RECEIVE_STYLE_VALUES_USED = ServeReceivePattern::RECEIVE_STYLE_VALUES
+
+  def initialize(match_info)
+    @patterns = match_info.serve_receive_patterns.to_a
+    @serve_patterns   = @patterns.select(&:origin_serve?)
+    @receive_patterns = @patterns.select(&:origin_receive?)
+  end
+
+  # ①サーブ長さ別得点率
+  def serve_length_stats
+    entries = ServeReceivePattern.serve_lengths.keys.filter_map do |length|
+      patterns = @serve_patterns.select { |p| p.serve_length == length }
+      next if patterns.empty?
+
+      build_stats(label: serve_length_label(length), patterns: patterns)
+    end
+    append_share(entries)
+  end
+
+  # ②サーブ（長さ+回転+3球目）組み合わせ別
+  def serve_pattern_stats
+    grouped = @serve_patterns.group_by { |p| [p.serve_length, p.serve_spins.sort, p.attack_style] }
+    mapped = grouped.map do |(length, spins, attack), patterns|
+      label = "#{serve_length_label(length)} #{spin_labels(spins)} → #{attack_label(attack)}"
+      build_stats(label: label, patterns: patterns)
+    end
+    append_share(mapped.sort_by { |s| -s[:score] })
+  end
+
+  # ③レシーブ技術別得点率
+  def receive_style_stats
+    entries = RECEIVE_STYLE_VALUES_USED.filter_map do |key, val|
+      patterns = @receive_patterns.select { |p| p.receive_style == val }
+      next if patterns.empty?
+
+      build_stats(label: Score.human_enum_name(:batting_style, key), patterns: patterns)
+    end
+    append_share(entries)
+  end
+
+  # ④レシーブ（技術+4球目）組み合わせ別
+  def receive_pattern_stats
+    grouped = @receive_patterns.group_by { |p| [p.receive_style, p.attack_style] }
+    mapped = grouped.map do |(recv, attack), patterns|
+      recv_label = recv ? Score.human_enum_name(:batting_style, receive_key(recv)) : '不明'
+      attack_label_str = attack_label(attack)
+      build_stats(label: "#{recv_label} → #{attack_label_str}", patterns: patterns)
+    end
+    append_share(mapped.sort_by { |s| -s[:score] })
+  end
+
+  # ⑤決着タイミング分布（全体・サーブ/レシーブ別）
+  def decided_at_distribution
+    {
+      all: decided_at_group(@patterns),
+      serve: decided_at_group(@serve_patterns),
+      receive: decided_at_group(@receive_patterns)
+    }
+  end
+
+  def empty?
+    @patterns.empty?
+  end
+
+  private
+
+  def build_stats(label:, patterns:)
+    score      = patterns.count(&:won)
+    lost_score = patterns.count { |p| !p.won }
+    total      = score + lost_score
+    rate       = total.positive? ? (score.to_f / total * 100).round : 0
+    { label: label, score: score, lost_score: lost_score, rate: rate, share: 0 }
+  end
+
+  def append_share(entries)
+    total = entries.sum { |e| e[:score] }
+    entries.map do |e|
+      share = total.positive? ? (e[:score].to_f / total * 100).round : 0
+      e.merge(share: share)
+    end
+  end
+
+  def serve_length_label(key)
+    I18n.t("activerecord.attributes.serve_receive_pattern.serve_length.#{key}")
+  end
+
+  def spin_labels(spins)
+    spins.map { |i| ServeReceivePattern::SERVE_SPIN_NAMES_JA[i] }.join('+')
+  end
+
+  def attack_label(key)
+    Score.human_enum_name(:batting_style, key)
+  end
+
+  def receive_key(val)
+    ServeReceivePattern::RECEIVE_STYLE_VALUES.key(val)
+  end
+
+  def decided_at_group(patterns)
+    ServeReceivePattern.decided_ats.keys.map do |key|
+      grp = patterns.select { |p| p.decided_at == key }
+      label = I18n.t("activerecord.attributes.serve_receive_pattern.decided_at.#{key}")
+      { label: label, score: grp.count(&:won), lost_score: grp.count { |p| !p.won } }
+    end
+  end
+end

--- a/app/views/match_infos/_serve_receive_analysis.html.erb
+++ b/app/views/match_infos/_serve_receive_analysis.html.erb
@@ -17,6 +17,7 @@
         <%= render 'match_infos/serve_receive_score_table',
                    data: srp_analysis.serve_length_stats,
                    theme: :player %>
+        <p class="text-muted small mt-1 mb-0">※ショート → ハーフロング → ロングの順で表示</p>
       <% end %>
 
       <h3 class="fs-5 mt-4 mb-3">サーブ→3球目 パターン別</h3>
@@ -26,6 +27,7 @@
         <%= render 'match_infos/serve_receive_score_table',
                    data: srp_analysis.serve_pattern_stats,
                    theme: :player %>
+        <p class="text-muted small mt-1 mb-0">※得点数の多い順で表示（上位のパターンが得意な組み合わせ）</p>
       <% end %>
     </div>
   </div>
@@ -35,13 +37,14 @@
     <div class="section-card p-4 shadow-sm">
       <h2 class="section-title mb-3">レシーブ起点の分析</h2>
 
-      <h3 class="fs-5 mb-3">レシーブ技術別得点率</h3>
-      <% if srp_analysis.receive_style_stats.empty? %>
+      <h3 class="fs-5 mb-3">レシーブエース・ミス</h3>
+      <% if srp_analysis.receive_direct_stats.empty? %>
         <p class="text-muted">データなし</p>
       <% else %>
         <%= render 'match_infos/serve_receive_score_table',
-                   data: srp_analysis.receive_style_stats,
+                   data: srp_analysis.receive_direct_stats,
                    theme: :player %>
+        <p class="text-muted small mt-1 mb-0">※得点数の多い順で表示</p>
       <% end %>
 
       <h3 class="fs-5 mt-4 mb-3">レシーブ→4球目 パターン別</h3>
@@ -51,6 +54,7 @@
         <%= render 'match_infos/serve_receive_score_table',
                    data: srp_analysis.receive_pattern_stats,
                    theme: :player %>
+        <p class="text-muted small mt-1 mb-0">※得点数の多い順で表示（上位のパターンが得意な組み合わせ）</p>
       <% end %>
     </div>
   </div>
@@ -59,42 +63,25 @@
   <% dist = srp_analysis.decided_at_distribution %>
   <div class="show-container fade-in-up mb-4">
     <div class="section-card p-4 shadow-sm">
-      <h2 class="section-title mb-3">決着タイミング分布</h2>
-      <div class="row g-3">
-        <div class="col-md-4">
-          <h3 class="fs-6 mb-2 text-center">サーブ起点</h3>
-          <% if dist[:serve].all? { |d| d[:score] + d[:lost_score] == 0 } %>
-            <p class="text-muted text-center">データなし</p>
-          <% else %>
-            <%= render 'match_infos/serve_receive_score_table',
-                       data: dist[:serve],
-                       theme: :player,
-                       show_share: false %>
-          <% end %>
-        </div>
-        <div class="col-md-4">
-          <h3 class="fs-6 mb-2 text-center">レシーブ起点</h3>
-          <% if dist[:receive].all? { |d| d[:score] + d[:lost_score] == 0 } %>
-            <p class="text-muted text-center">データなし</p>
-          <% else %>
-            <%= render 'match_infos/serve_receive_score_table',
-                       data: dist[:receive],
-                       theme: :player,
-                       show_share: false %>
-          <% end %>
-        </div>
-        <div class="col-md-4">
-          <h3 class="fs-6 mb-2 text-center">全体</h3>
-          <% if dist[:all].all? { |d| d[:score] + d[:lost_score] == 0 } %>
-            <p class="text-muted text-center">データなし</p>
-          <% else %>
-            <%= render 'match_infos/serve_receive_score_table',
-                       data: dist[:all],
-                       theme: :player,
-                       show_share: false %>
-          <% end %>
-        </div>
-      </div>
+      <h2 class="section-title mb-3">得点タイミング分布</h2>
+      <h3 class="fs-6 mb-2">サーブ起点</h3>
+      <% if dist[:serve].all? { |d| d[:score] + d[:lost_score] == 0 } %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: dist[:serve],
+                   theme: :player,
+                   show_share: false %>
+      <% end %>
+      <h3 class="fs-6 mt-4 mb-2">レシーブ起点</h3>
+      <% if dist[:receive].all? { |d| d[:score] + d[:lost_score] == 0 } %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: dist[:receive],
+                   theme: :player,
+                   show_share: false %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/match_infos/_serve_receive_analysis.html.erb
+++ b/app/views/match_infos/_serve_receive_analysis.html.erb
@@ -1,0 +1,100 @@
+<% if srp_analysis.empty? %>
+  <div class="show-container fade-in-up mb-4">
+    <div class="section-card p-4 shadow-sm">
+      <p class="text-muted text-center mb-0">まだ得点データがありません</p>
+    </div>
+  </div>
+<% else %>
+  <%# サーブ起点の分析 %>
+  <div class="show-container fade-in-up mb-4">
+    <div class="section-card p-4 shadow-sm">
+      <h2 class="section-title mb-3">サーブ起点の分析</h2>
+
+      <h3 class="fs-5 mb-3">サーブ長さ別得点率</h3>
+      <% if srp_analysis.serve_length_stats.empty? %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: srp_analysis.serve_length_stats,
+                   theme: :player %>
+      <% end %>
+
+      <h3 class="fs-5 mt-4 mb-3">サーブ→3球目 パターン別</h3>
+      <% if srp_analysis.serve_pattern_stats.empty? %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: srp_analysis.serve_pattern_stats,
+                   theme: :player %>
+      <% end %>
+    </div>
+  </div>
+
+  <%# レシーブ起点の分析 %>
+  <div class="show-container fade-in-up mb-4">
+    <div class="section-card p-4 shadow-sm">
+      <h2 class="section-title mb-3">レシーブ起点の分析</h2>
+
+      <h3 class="fs-5 mb-3">レシーブ技術別得点率</h3>
+      <% if srp_analysis.receive_style_stats.empty? %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: srp_analysis.receive_style_stats,
+                   theme: :player %>
+      <% end %>
+
+      <h3 class="fs-5 mt-4 mb-3">レシーブ→4球目 パターン別</h3>
+      <% if srp_analysis.receive_pattern_stats.empty? %>
+        <p class="text-muted">データなし</p>
+      <% else %>
+        <%= render 'match_infos/serve_receive_score_table',
+                   data: srp_analysis.receive_pattern_stats,
+                   theme: :player %>
+      <% end %>
+    </div>
+  </div>
+
+  <%# 決着タイミング分布 %>
+  <% dist = srp_analysis.decided_at_distribution %>
+  <div class="show-container fade-in-up mb-4">
+    <div class="section-card p-4 shadow-sm">
+      <h2 class="section-title mb-3">決着タイミング分布</h2>
+      <div class="row g-3">
+        <div class="col-md-4">
+          <h3 class="fs-6 mb-2 text-center">サーブ起点</h3>
+          <% if dist[:serve].all? { |d| d[:score] + d[:lost_score] == 0 } %>
+            <p class="text-muted text-center">データなし</p>
+          <% else %>
+            <%= render 'match_infos/serve_receive_score_table',
+                       data: dist[:serve],
+                       theme: :player,
+                       show_share: false %>
+          <% end %>
+        </div>
+        <div class="col-md-4">
+          <h3 class="fs-6 mb-2 text-center">レシーブ起点</h3>
+          <% if dist[:receive].all? { |d| d[:score] + d[:lost_score] == 0 } %>
+            <p class="text-muted text-center">データなし</p>
+          <% else %>
+            <%= render 'match_infos/serve_receive_score_table',
+                       data: dist[:receive],
+                       theme: :player,
+                       show_share: false %>
+          <% end %>
+        </div>
+        <div class="col-md-4">
+          <h3 class="fs-6 mb-2 text-center">全体</h3>
+          <% if dist[:all].all? { |d| d[:score] + d[:lost_score] == 0 } %>
+            <p class="text-muted text-center">データなし</p>
+          <% else %>
+            <%= render 'match_infos/serve_receive_score_table',
+                       data: dist[:all],
+                       theme: :player,
+                       show_share: false %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/match_infos/_serve_receive_input.html.erb
+++ b/app/views/match_infos/_serve_receive_input.html.erb
@@ -1,4 +1,4 @@
-<div class="rally-input-container" data-controller="serve-receive-input">
+<div class="rally-input-container">
 
   <%# サーブ権選択エリア %>
   <div class="rally-server-select-area" data-serve-receive-input-target="serverSelect">

--- a/app/views/match_infos/_serve_receive_score_table.html.erb
+++ b/app/views/match_infos/_serve_receive_score_table.html.erb
@@ -14,7 +14,7 @@
     <thead class="<%= header_cls %>">
       <tr>
         <th class="text-center rank-col">#</th>
-        <th>技術</th>
+        <th class="text-wrap" style="min-width: 8rem">技術</th>
         <th class="text-center">得点数</th>
         <th class="text-center">失点数</th>
         <th class="text-center">得点率</th>
@@ -27,7 +27,7 @@
       <% data.each.with_index(1) do |entry, rank| %>
         <tr>
           <td class="text-center"><span class="rank-badge <%= rank_cls %>"><%= rank %></span></td>
-          <td><%= entry[:label] %></td>
+          <td class="text-wrap" style="min-width: 8rem"><%= entry[:label] %></td>
           <td class="text-center"><%= entry[:score] %></td>
           <td class="text-center"><%= entry[:lost_score] %></td>
           <td class="text-center"><strong><%= entry[:rate] %>%</strong></td>
@@ -40,41 +40,41 @@
   </table>
 </div>
 
-<table class="table d-none d-md-table mb-0">
-  <thead class="<%= header_cls %>">
-    <tr>
-      <th class="text-center rank-col">#</th>
-      <th>技術名</th>
-      <th class="text-end">得点数</th>
-      <th class="text-end">失点数</th>
-      <th class="text-end">得点率</th>
-      <% if show_share %>
-        <th class="text-end">シェア</th>
-      <% end %>
-      <th class="rate-bar-col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% data.each.with_index(1) do |entry, rank| %>
+<div class="overflow-auto d-none d-md-block">
+  <table class="table text-nowrap mb-0">
+    <thead class="<%= header_cls %>">
       <tr>
-        <td class="text-center"><span class="rank-badge <%= rank_cls %>"><%= rank %></span></td>
-        <td><%= entry[:label] %></td>
-        <td class="text-end"><%= entry[:score] %></td>
-        <td class="text-end"><%= entry[:lost_score] %></td>
-        <td class="text-end"><strong><%= entry[:rate] %>%</strong></td>
+        <th class="text-center rank-col">#</th>
+        <th class="text-wrap">技術名</th>
+        <th class="text-end">得点数</th>
+        <th class="text-end">失点数</th>
         <% if show_share %>
-          <td class="text-end"><%= entry[:share] %>%</td>
+          <th class="text-end">シェア</th>
         <% end %>
-        <td class="align-middle">
-          <% bar_width = theme == :player ? entry[:rate] : (100 - entry[:rate]) %>
-          <div class="d-flex align-items-center gap-2">
-            <div class="rate-bar-container flex-grow-1">
-              <div class="<%= bar_class %>" style="width: <%= bar_width %>%;"></div>
-            </div>
-            <span class="rate-bar-pct"><%= bar_width %>%</span>
-          </div>
-        </td>
+        <th class="rate-bar-col">得点率</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% data.each.with_index(1) do |entry, rank| %>
+        <tr>
+          <td class="text-center"><span class="rank-badge <%= rank_cls %>"><%= rank %></span></td>
+          <td class="text-wrap"><%= entry[:label] %></td>
+          <td class="text-end"><%= entry[:score] %></td>
+          <td class="text-end"><%= entry[:lost_score] %></td>
+          <% if show_share %>
+            <td class="text-end"><%= entry[:share] %>%</td>
+          <% end %>
+          <td class="align-middle">
+            <% bar_width = theme == :player ? entry[:rate] : (100 - entry[:rate]) %>
+            <div class="d-flex align-items-center gap-2">
+              <div class="rate-bar-container flex-grow-1">
+                <div class="<%= bar_class %>" style="width: <%= bar_width %>%;"></div>
+              </div>
+              <span class="rate-bar-pct"><%= bar_width %>%</span>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/match_infos/_serve_receive_score_table.html.erb
+++ b/app/views/match_infos/_serve_receive_score_table.html.erb
@@ -1,0 +1,80 @@
+<%
+  theme      = local_assigns.fetch(:theme, :player)
+  show_share = local_assigns.fetch(:show_share, true)
+  bar_class  = theme == :opponent ? 'rate-bar-fill-opponent' : 'rate-bar-fill-player'
+  rank_cls   = theme == :opponent ? 'rank-badge-opponent'    : 'rank-badge-player'
+  header_cls = case theme
+               when :player   then 'ranking-table-player-header'
+               when :opponent then 'ranking-table-opponent-header'
+               end
+%>
+
+<div class="overflow-auto d-md-none">
+  <table class="table text-nowrap mb-0">
+    <thead class="<%= header_cls %>">
+      <tr>
+        <th class="text-center rank-col">#</th>
+        <th>技術</th>
+        <th class="text-center">得点数</th>
+        <th class="text-center">失点数</th>
+        <th class="text-center">得点率</th>
+        <% if show_share %>
+          <th class="text-center">シェア</th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% data.each.with_index(1) do |entry, rank| %>
+        <tr>
+          <td class="text-center"><span class="rank-badge <%= rank_cls %>"><%= rank %></span></td>
+          <td><%= entry[:label] %></td>
+          <td class="text-center"><%= entry[:score] %></td>
+          <td class="text-center"><%= entry[:lost_score] %></td>
+          <td class="text-center"><strong><%= entry[:rate] %>%</strong></td>
+          <% if show_share %>
+            <td class="text-center"><%= entry[:share] %>%</td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<table class="table d-none d-md-table mb-0">
+  <thead class="<%= header_cls %>">
+    <tr>
+      <th class="text-center rank-col">#</th>
+      <th>技術名</th>
+      <th class="text-end">得点数</th>
+      <th class="text-end">失点数</th>
+      <th class="text-end">得点率</th>
+      <% if show_share %>
+        <th class="text-end">シェア</th>
+      <% end %>
+      <th class="rate-bar-col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% data.each.with_index(1) do |entry, rank| %>
+      <tr>
+        <td class="text-center"><span class="rank-badge <%= rank_cls %>"><%= rank %></span></td>
+        <td><%= entry[:label] %></td>
+        <td class="text-end"><%= entry[:score] %></td>
+        <td class="text-end"><%= entry[:lost_score] %></td>
+        <td class="text-end"><strong><%= entry[:rate] %>%</strong></td>
+        <% if show_share %>
+          <td class="text-end"><%= entry[:share] %>%</td>
+        <% end %>
+        <td class="align-middle">
+          <% bar_width = theme == :player ? entry[:rate] : (100 - entry[:rate]) %>
+          <div class="d-flex align-items-center gap-2">
+            <div class="rate-bar-container flex-grow-1">
+              <div class="<%= bar_class %>" style="width: <%= bar_width %>%;"></div>
+            </div>
+            <span class="rate-bar-pct"><%= bar_width %>%</span>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/match_infos/index.html.erb
+++ b/app/views/match_infos/index.html.erb
@@ -1,8 +1,10 @@
 <h1 class="center-text">📝 試合分析一覧</h1>
 
-<div class="d-flex justify-content-center gap-2 mb-3">
-  <%= link_to "サーブ・レシーブ分析を開始", new_serve_receive_match_infos_path, class: "btn btn-primary" %>
-  <%= link_to "技術別得点率分析を開始", new_match_info_path, class: "btn btn-success" %>
+<div class="d-flex justify-content-center mb-3">
+  <div class="d-flex flex-column flex-sm-row gap-2">
+    <%= link_to "サーブ・レシーブ分析を開始", new_serve_receive_match_infos_path, class: "btn btn-primary" %>
+    <%= link_to "技術別得点率分析を開始", new_match_info_path, class: "btn btn-success" %>
+  </div>
 </div>
 
 <div data-controller="auto-save" data-auto-save-page-value="index"

--- a/app/views/match_infos/show.html.erb
+++ b/app/views/match_infos/show.html.erb
@@ -1,7 +1,6 @@
 <h1 class="center-text">📝 試合分析詳細</h1>
 
 <% if @match_info.serve_receive? %>
-  <%= render 'match_infos/match_info_detail', match_info: @match_info %>
   <%= render 'match_infos/serve_receive_analysis', srp_analysis: @srp_analysis %>
 <% else %>
   <%= render partial: "match_info_detail", locals: { match_info: @match_info } %>
@@ -31,7 +30,6 @@
 <% end %>
 
 <div class="center-button">
-  <%= link_to "編集", edit_match_info_path(@match_info), class: "btn edit-btn" %>
   <button type="button" class="btn delete-btn" data-bs-toggle="modal" data-bs-target="#deleteConfirmModal">
     削除
   </button>

--- a/app/views/match_infos/show.html.erb
+++ b/app/views/match_infos/show.html.erb
@@ -1,29 +1,34 @@
 <h1 class="center-text">📝 試合分析詳細</h1>
 
-<%= render partial: "match_info_detail", locals: { match_info: @match_info } %>
+<% if @match_info.serve_receive? %>
+  <%= render 'match_infos/match_info_detail', match_info: @match_info %>
+  <%= render 'match_infos/serve_receive_analysis', srp_analysis: @srp_analysis %>
+<% else %>
+  <%= render partial: "match_info_detail", locals: { match_info: @match_info } %>
 
-<% if @match_info.rallies.any? %>
+  <% if @match_info.rallies.any? %>
+    <div class="show-container fade-in-up mb-4">
+      <div class="section-card p-4 shadow-sm">
+        <div class="d-flex align-items-center mb-3">
+          <h2 class="section-title mb-0 me-2">得点推移表</h2>
+          <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#abbrListModal">
+            略称一覧
+          </button>
+        </div>
+        <p class="text-muted small mb-2">※ラリー入力時のデータに基づきます</p>
+        <%= render partial: "score_progression", locals: { match_info: @match_info } %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="show-container fade-in-up mb-4">
     <div class="section-card p-4 shadow-sm">
-      <div class="d-flex align-items-center mb-3">
-        <h2 class="section-title mb-0 me-2">得点推移表</h2>
-        <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#abbrListModal">
-          略称一覧
-        </button>
+      <div class="advice-section">
+        <%= simple_format(@advice) %>
       </div>
-      <p class="text-muted small mb-2">※ラリー入力時のデータに基づきます</p>
-      <%= render partial: "score_progression", locals: { match_info: @match_info } %>
     </div>
   </div>
 <% end %>
-
-<div class="show-container fade-in-up mb-4">
-  <div class="section-card p-4 shadow-sm">
-    <div class="advice-section">
-      <%= simple_format(@advice) %>
-    </div>
-  </div>
-</div>
 
 <div class="center-button">
   <%= link_to "編集", edit_match_info_path(@match_info), class: "btn edit-btn" %>
@@ -32,7 +37,7 @@
   </button>
 </div>
 
-<% if @match_info.rallies.any? %>
+<% if !@match_info.serve_receive? && @match_info.rallies.any? %>
 <div class="modal fade" id="abbrListModal" tabindex="-1" aria-labelledby="abbrListModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-sm">
     <div class="modal-content">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,6 +48,14 @@ ja:
           attack_ball: 3・4球目
           follow_ball: 5・6球目
           rally: ラリー
+        decided_at_serve:
+          attack_ball: 3球目
+          follow_ball: 5球目
+          rally: 7球目以降
+        decided_at_receive:
+          attack_ball: 4球目
+          follow_ball: 6球目
+          rally: 8球目以降
         serve_spin:
           backspin: 下回転
           topspin: 上回転
@@ -58,6 +66,24 @@ ja:
           service_ace: サービスエース
           receive_ace: レシーブエース
           receive_miss: レシーブミス
+          fore_drive_vs_topspin: 対上回転フォアドライブ
+          back_drive_vs_topspin: 対上回転バックドライブ
+          fore_drive_vs_backspin: 対下回転フォアドライブ
+          back_drive_vs_backspin: 対下回転バックドライブ
+          fore_push: フォアツッツキ
+          back_push: バックツッツキ
+          fore_stop: フォアストップ
+          back_stop: バックストップ
+          fore_flick: フォアフリック
+          back_flick: バックフリック
+          chiquita: チキータ
+          fore_block: フォアブロック
+          back_block: バックブロック
+          fore_counter: フォアカウンター
+          back_counter: バックカウンター
+          fore_smash: フォアスマッシュ
+          back_smash: バックスマッシュ
+          net_or_edge: ネットorエッジ
   defaults:
     password_reset: "パスワードリセットのご案内"
   notices:

--- a/plans/77-phase-0-77-1-replicated-twilight-md-7-whimsical-quokka.md
+++ b/plans/77-phase-0-77-1-replicated-twilight-md-7-whimsical-quokka.md
@@ -1,0 +1,299 @@
+# Sprint 3 — サーブ・レシーブ専用分析ページ
+
+## Context
+
+Sprint 1でデータ基盤、Sprint 2で入力フローを実装済み。保存された `ServeReceivePattern` レコードを集計・可視化する「専用分析ページ」を実装する。既存の `show.html.erb` に `analysis_type` 分岐を追加し、5軸の集計表を表示する。
+
+---
+
+## ブランチ
+
+`feature/sprint-3-serve-receive-analysis`
+
+---
+
+## 実装ステップ
+
+### Step 1: `ServeReceiveAnalyzer` サービス新規作成
+
+**ファイル**: `app/services/serve_receive_analyzer.rb`
+
+`RallyContextBuilder` の構造（initialize → private キャッシュ → 公開メソッドで整形済みデータ返却）を参考にする。
+
+```ruby
+class ServeReceiveAnalyzer
+  def initialize(match_info)
+    @patterns = match_info.serve_receive_patterns.to_a
+    @serve_patterns  = @patterns.select(&:origin_serve?)
+    @receive_patterns = @patterns.select(&:origin_receive?)
+  end
+
+  # ①サーブ長さ別得点率
+  def serve_length_stats
+    ServeReceivePattern.serve_lengths.keys.filter_map do |length|
+      patterns = @serve_patterns.select { |p| p.serve_length == length }
+      next if patterns.empty?
+      build_stats(label: serve_length_label(length), patterns:)
+    end.then { append_share(_1) }
+  end
+
+  # ②サーブ（長さ+回転+3球目）組み合わせ別
+  def serve_pattern_stats
+    @serve_patterns
+      .group_by { |p| [p.serve_length, p.serve_spins.sort, p.attack_style] }
+      .map do |(length, spins, attack), patterns|
+        label = "#{serve_length_label(length)} #{spin_labels(spins)} → #{attack_label(attack)}"
+        build_stats(label:, patterns:)
+      end
+      .sort_by { |s| -s[:score] }
+      .then { append_share(_1) }
+  end
+
+  # ③レシーブ技術別得点率
+  def receive_style_stats
+    RECEIVE_STYLE_VALUES_USED.filter_map do |key, val|
+      patterns = @receive_patterns.select { |p| p.receive_style == val }
+      next if patterns.empty?
+      build_stats(label: Score.human_enum_name(:batting_style, key), patterns:)
+    end.then { append_share(_1) }
+  end
+
+  # ④レシーブ（技術+4球目）組み合わせ別
+  def receive_pattern_stats
+    @receive_patterns
+      .group_by { |p| [p.receive_style, p.attack_style] }
+      .map do |(recv, attack), patterns|
+        recv_label  = recv  ? Score.human_enum_name(:batting_style, receive_key(recv))  : '不明'
+        attack_label_str = attack_label(attack)
+        build_stats(label: "#{recv_label} → #{attack_label_str}", patterns:)
+      end
+      .sort_by { |s| -s[:score] }
+      .then { append_share(_1) }
+  end
+
+  # ⑤決着タイミング分布（全体・サーブ/レシーブ別3本ずつ）
+  def decided_at_distribution
+    {
+      all:     decided_at_group(@patterns),
+      serve:   decided_at_group(@serve_patterns),
+      receive: decided_at_group(@receive_patterns)
+    }
+  end
+
+  def empty?
+    @patterns.empty?
+  end
+
+  private
+
+  def build_stats(label:, patterns:)
+    score      = patterns.count(&:won)
+    lost_score = patterns.count { |p| !p.won }
+    total      = score + lost_score
+    rate       = total.positive? ? (score.to_f / total * 100).round : 0
+    { label:, score:, lost_score:, rate:, share: 0 }
+  end
+
+  def append_share(entries)
+    total = entries.sum { |e| e[:score] }
+    entries.map do |e|
+      share = total.positive? ? (e[:score].to_f / total * 100).round : 0
+      e.merge(share:)
+    end
+  end
+
+  def serve_length_label(key)
+    I18n.t("activerecord.attributes.serve_receive_pattern.serve_length.#{key}")
+  end
+
+  def spin_labels(spins)
+    spins.map { |i| ServeReceivePattern::SERVE_SPIN_NAMES_JA[i] }.join('+')
+  end
+
+  def attack_label(key)
+    Score.human_enum_name(:batting_style, key)
+  end
+
+  def receive_key(val)
+    ServeReceivePattern::RECEIVE_STYLE_VALUES.key(val)
+  end
+
+  def decided_at_group(patterns)
+    ServeReceivePattern.decided_ats.keys.map do |key|
+      grp = patterns.select { |p| p.decided_at == key }
+      label = I18n.t("activerecord.attributes.serve_receive_pattern.decided_at.#{key}")
+      { label:, score: grp.count(&:won), lost_score: grp.count { |p| !p.won } }
+    end
+  end
+end
+```
+
+**重要ポイント**:
+- `origin` enum はプレフィックス `:origin` 付き（`origin_serve?` / `origin_receive?`）。
+- `attack_style` enum もプレフィックス `:attack` 付き。`attack_style` の値はシンボルキーか文字列かを `attack_label` で吸収する。
+- `receive_style` は integer（enum ではない）で `RECEIVE_STYLE_VALUES` で逆引き。
+- `RECEIVE_STYLE_VALUES_USED` は `ServeReceivePattern::RECEIVE_STYLE_VALUES` を参照（定数はモデル側にある）。
+
+### Step 2: showアクションに `analysis_type` 分岐を追加
+
+**ファイル**: `app/controllers/match_infos_controller.rb`
+
+```ruby
+def show
+  set_match_info_scores
+  if @match_info.serve_receive?
+    @srp_analysis = ServeReceiveAnalyzer.new(@match_info)
+  else
+    # 既存のAIアドバイス処理（変更なし）
+    if @match_info.advice.present?
+      @advice = @match_info.advice
+    else
+      advice = ChatgptService.get_advice(@match_info)
+      @match_info.update_advice(advice)
+      @advice = advice
+    end
+  end
+end
+```
+
+`set_match_info_scores` は変更不要（`@match_info` と `@batting_scores` を取得）。
+
+### Step 3: `_serve_receive_score_table.html.erb` partial 新規作成
+
+**ファイル**: `app/views/match_infos/_serve_receive_score_table.html.erb`
+
+`_batting_score_table.html.erb` のレスポンシブ2テーブル構造・プログレスバー・ランクバッジを流用しつつ、技術名表示を `label` 直挿しに変更する。
+
+- `locals`: `data` (array), `theme` (:player or :opponent), `show_share` (boolean, default true)
+- `data` の各要素: `{ label:, score:, lost_score:, rate:, share: }`
+- 技術名セルは `<td><%= entry[:label] %></td>` に（`Score.human_enum_name` 呼び出し不要）
+- プログレスバーの `bar_width` は `theme == :player ? entry[:rate] : (100 - entry[:rate])` で計算（`_batting_score_table` と同ロジック）
+- `show_share` が false の場合、シェア列を非表示（決着タイミング分布テーブルで使用）
+
+### Step 4: `_serve_receive_analysis.html.erb` partial 新規作成
+
+**ファイル**: `app/views/match_infos/_serve_receive_analysis.html.erb`
+
+```
+locals: srp_analysis (ServeReceiveAnalyzer)
+```
+
+**セクション構成**:
+
+```
+[データなしの場合]
+  「まだ得点データがありません」メッセージ
+
+[データあり]
+  h2: 「サーブ起点の分析」
+    h3: 「サーブ長さ別得点率」
+      render '_serve_receive_score_table', data: srp_analysis.serve_length_stats, theme: :player
+    h3: 「サーブ→3球目 パターン別」
+      render '_serve_receive_score_table', data: srp_analysis.serve_pattern_stats, theme: :player
+
+  h2: 「レシーブ起点の分析」
+    h3: 「レシーブ技術別得点率」
+      render '_serve_receive_score_table', data: srp_analysis.receive_style_stats, theme: :player
+    h3: 「レシーブ→4球目 パターン別」
+      render '_serve_receive_score_table', data: srp_analysis.receive_pattern_stats, theme: :player
+
+  h2: 「決着タイミング分布」
+    (サーブ・レシーブ・全体 の3列を横並びカード or テーブルで表示)
+    render '_serve_receive_score_table', data: dist[:serve], theme: :player, show_share: false
+    render '_serve_receive_score_table', data: dist[:receive], theme: :player, show_share: false
+    render '_serve_receive_score_table', data: dist[:all], theme: :player, show_share: false
+```
+
+各セクションは `data.empty?` の場合「データなし」メッセージを表示して skip。
+
+### Step 5: `show.html.erb` に分岐を追加
+
+**ファイル**: `app/views/match_infos/show.html.erb`
+
+既存コードの先頭付近に分岐を追加:
+
+```erb
+<% if @match_info.serve_receive? %>
+  <%= render 'match_infos/match_info_detail', match_info: @match_info %>
+  <%= render 'match_infos/serve_receive_analysis', srp_analysis: @srp_analysis %>
+<% else %>
+  <%# 既存の表示（rallies/アドバイス/スコア推移）をそのまま %>
+  ...
+<% end %>
+```
+
+`_match_info_detail` はゲームスコア表示を含むため両方で流用できる。
+
+### Step 6: テスト
+
+**`spec/services/serve_receive_analyzer_spec.rb`** 新規作成:
+
+```
+- describe #serve_length_stats
+  - ショートサーブで3得点2失点のデータ → rate: 60, label: "ショート"
+  - データなし → 空配列
+- describe #serve_pattern_stats
+  - 同一組み合わせを複数件 → まとめて集計
+  - label フォーマット確認（"ショート 下回転+順横回転 → フォアドライブ（対下）"）
+- describe #receive_style_stats
+  - receive_style あり → 正しくラベル表示
+- describe #receive_pattern_stats
+  - 組み合わせ別集計・ソート確認
+- describe #decided_at_distribution
+  - attack_ball / follow_ball / rally それぞれ集計
+  - serve / receive 分離確認
+- describe #empty?
+  - patternがゼロのとき true
+```
+
+**`spec/requests/match_infos_spec.rb`** に追記:
+
+```
+- GET /match_infos/:id (serve_receive? な match_info)
+  - 200を返すこと
+  - @srp_analysis が ServeReceiveAnalyzer のインスタンスであること
+  - AIアドバイス処理が呼ばれないこと
+```
+
+---
+
+## 流用する既存実装
+
+| 用途 | 流用元 |
+|------|--------|
+| サービスクラスの構造 | `app/services/rally_context_builder.rb` |
+| テーブルのHTML構造・レスポンシブ・バー | `app/views/match_infos/_batting_score_table.html.erb` |
+| 技術の和名取得 | `Score.human_enum_name(:batting_style, key)` |
+| 試合情報ヘッダー表示 | `app/views/match_infos/_match_info_detail.html.erb` |
+| I18n キー（serve_length / decided_at） | `config/locales/ja.yml`（Sprint 1で追加済み） |
+| SERVE_SPIN_NAMES_JA / RECEIVE_STYLE_VALUES | `app/models/serve_receive_pattern.rb` |
+
+---
+
+## 新規作成ファイル
+
+| ファイル | 用途 |
+|---------|------|
+| `app/services/serve_receive_analyzer.rb` | 5軸集計ロジック |
+| `app/views/match_infos/_serve_receive_score_table.html.erb` | ラベル直挿しテーブル partial |
+| `app/views/match_infos/_serve_receive_analysis.html.erb` | 分析ページ全体 partial |
+| `spec/services/serve_receive_analyzer_spec.rb` | サービステスト |
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/controllers/match_infos_controller.rb` | show アクションに `serve_receive?` 分岐を追加 |
+| `app/views/match_infos/show.html.erb` | `serve_receive?` 分岐で新 partial をレンダー |
+
+---
+
+## 検証方法
+
+1. `bundle exec rspec && bundle exec rubocop --parallel` が両方グリーン
+2. `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` が 200
+3. ブラウザ操作:
+   - Sprint 2 で作成したサーブ・レシーブ分析の試合を `show` ページで開く
+   - 5セクション（サーブ長さ別 / サーブパターン別 / レシーブ別 / レシーブパターン別 / 決着タイミング）が表示されること
+   - 入力データが0件の試合では「データなし」メッセージが出ること
+   - 既存の `technique` 分析の show ページが壊れていないこと（AIアドバイス・スコア推移が正常表示）

--- a/spec/requests/match_infos_spec.rb
+++ b/spec/requests/match_infos_spec.rb
@@ -84,6 +84,25 @@ RSpec.describe "MatchInfos", type: :request do
         expect(response.body).not_to include("game-score-summary")
       end
     end
+
+    context "serve_receive? な match_info の場合" do
+      let(:srp_match_info) { create(:match_info, user: user, analysis_type: :serve_receive) }
+
+      it "200を返すこと" do
+        get match_info_path(srp_match_info)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "@srp_analysis が ServeReceiveAnalyzer のインスタンスであること" do
+        get match_info_path(srp_match_info)
+        expect(controller.instance_variable_get(:@srp_analysis)).to be_a(ServeReceiveAnalyzer)
+      end
+
+      it "AIアドバイス処理が呼ばれないこと" do
+        expect(ChatgptService).not_to receive(:get_advice)
+        get match_info_path(srp_match_info)
+      end
+    end
   end
 
   describe "GET /match_infos/new" do

--- a/spec/services/serve_receive_analyzer_spec.rb
+++ b/spec/services/serve_receive_analyzer_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+RSpec.describe ServeReceiveAnalyzer do
+  let(:user) { create(:user) }
+  let(:match_info) { create(:match_info, user: user, analysis_type: :serve_receive) }
+  let(:game) { create(:game, match_info: match_info, game_number: 1) }
+
+  def create_serve_pattern(attrs = {})
+    defaults = {
+      match_info: match_info,
+      game: game,
+      game_number: 1,
+      sequence_number: ServeReceivePattern.count + 1,
+      origin: :serve,
+      serve_length: :short,
+      serve_spins: [0],
+      attack_style: :fore_drive_vs_backspin,
+      decided_at: :attack_ball,
+      won: true
+    }
+    create(:serve_receive_pattern, defaults.merge(attrs))
+  end
+
+  def create_receive_pattern(attrs = {})
+    defaults = {
+      match_info: match_info,
+      game: game,
+      game_number: 1,
+      sequence_number: ServeReceivePattern.count + 1,
+      origin: :receive,
+      receive_style: ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita],
+      attack_style: :fore_drive_vs_backspin,
+      decided_at: :attack_ball,
+      won: true
+    }
+    create(:serve_receive_pattern, defaults.merge(attrs))
+  end
+
+  describe '#serve_length_stats' do
+    context 'ショートサーブで3得点2失点のデータがある場合' do
+      before do
+        3.times { create_serve_pattern(serve_length: :short, won: true) }
+        2.times { create_serve_pattern(serve_length: :short, won: false) }
+      end
+
+      it 'rate: 60, label: "ショート" を返すこと' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.serve_length_stats
+        expect(result).not_to be_empty
+        short_stat = result.find { |s| s[:label] == 'ショート' }
+        expect(short_stat).not_to be_nil
+        expect(short_stat[:score]).to eq(3)
+        expect(short_stat[:lost_score]).to eq(2)
+        expect(short_stat[:rate]).to eq(60)
+      end
+    end
+
+    context 'データなしの場合' do
+      it '空配列を返すこと' do
+        analyzer = described_class.new(match_info)
+        expect(analyzer.serve_length_stats).to eq([])
+      end
+    end
+  end
+
+  describe '#serve_pattern_stats' do
+    context '同一組み合わせを複数件入力した場合' do
+      before do
+        3.times do
+          create_serve_pattern(serve_length: :short, serve_spins: [0], attack_style: :fore_drive_vs_backspin, won: true)
+        end
+        create_serve_pattern(serve_length: :short, serve_spins: [0], attack_style: :fore_drive_vs_backspin, won: false)
+      end
+
+      it 'まとめて集計されること' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.serve_pattern_stats
+        expect(result.length).to eq(1)
+        expect(result.first[:score]).to eq(3)
+        expect(result.first[:lost_score]).to eq(1)
+      end
+
+      it 'label フォーマットが正しいこと' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.serve_pattern_stats
+        expect(result.first[:label]).to include('ショート')
+        expect(result.first[:label]).to include('下回転')
+        expect(result.first[:label]).to include('→')
+      end
+    end
+  end
+
+  describe '#receive_style_stats' do
+    context 'receive_style があるデータが存在する場合' do
+      before do
+        chiquita_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita]
+        2.times { create_receive_pattern(receive_style: chiquita_val, won: true) }
+        create_receive_pattern(receive_style: chiquita_val, won: false)
+      end
+
+      it '正しくラベルを表示すること' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.receive_style_stats
+        expect(result).not_to be_empty
+        chiquita_stat = result.find { |s| s[:label].include?('チキータ') }
+        expect(chiquita_stat).not_to be_nil
+        expect(chiquita_stat[:score]).to eq(2)
+        expect(chiquita_stat[:lost_score]).to eq(1)
+      end
+    end
+  end
+
+  describe '#receive_pattern_stats' do
+    context '組み合わせ別に集計される場合' do
+      before do
+        chiquita_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita]
+        fore_push_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:fore_push]
+        3.times do
+          create_receive_pattern(receive_style: chiquita_val, attack_style: :fore_drive_vs_backspin, won: true)
+        end
+        create_receive_pattern(receive_style: fore_push_val, attack_style: :back_push, won: true)
+      end
+
+      it '組み合わせ別に集計されること' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.receive_pattern_stats
+        expect(result.length).to eq(2)
+      end
+
+      it '得点数の降順でソートされること' do
+        analyzer = described_class.new(match_info)
+        result = analyzer.receive_pattern_stats
+        scores = result.map { |s| s[:score] }
+        expect(scores).to eq(scores.sort.reverse)
+      end
+    end
+  end
+
+  describe '#decided_at_distribution' do
+    before do
+      2.times { create_serve_pattern(decided_at: :attack_ball, won: true) }
+      create_serve_pattern(decided_at: :follow_ball, won: false)
+      2.times { create_receive_pattern(decided_at: :rally, won: true) }
+    end
+
+    it 'attack_ball / follow_ball / rally それぞれ集計されること' do
+      analyzer = described_class.new(match_info)
+      dist = analyzer.decided_at_distribution
+      all = dist[:all]
+      attack_ball = all.find { |d| d[:label] == '3・4球目' }
+      follow_ball = all.find { |d| d[:label] == '5・6球目' }
+      rally = all.find { |d| d[:label] == 'ラリー' }
+      expect(attack_ball[:score]).to eq(2)
+      expect(follow_ball[:lost_score]).to eq(1)
+      expect(rally[:score]).to eq(2)
+    end
+
+    it 'serve / receive が分離されること' do
+      analyzer = described_class.new(match_info)
+      dist = analyzer.decided_at_distribution
+      serve_dist = dist[:serve]
+      receive_dist = dist[:receive]
+
+      serve_attack = serve_dist.find { |d| d[:label] == '3・4球目' }
+      expect(serve_attack[:score]).to eq(2)
+
+      receive_rally = receive_dist.find { |d| d[:label] == 'ラリー' }
+      expect(receive_rally[:score]).to eq(2)
+    end
+  end
+
+  describe '#empty?' do
+    context 'patternがゼロのとき' do
+      it 'true を返すこと' do
+        analyzer = described_class.new(match_info)
+        expect(analyzer.empty?).to be true
+      end
+    end
+
+    context 'patternがあるとき' do
+      before { create_serve_pattern }
+
+      it 'false を返すこと' do
+        analyzer = described_class.new(match_info)
+        expect(analyzer.empty?).to be false
+      end
+    end
+  end
+end

--- a/spec/services/serve_receive_analyzer_spec.rb
+++ b/spec/services/serve_receive_analyzer_spec.rb
@@ -90,22 +90,34 @@ RSpec.describe ServeReceiveAnalyzer do
     end
   end
 
-  describe '#receive_style_stats' do
-    context 'receive_style があるデータが存在する場合' do
+  describe '#receive_direct_stats' do
+    context 'レシーブエース・ミスのデータが存在する場合' do
       before do
         chiquita_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita]
-        2.times { create_receive_pattern(receive_style: chiquita_val, won: true) }
-        create_receive_pattern(receive_style: chiquita_val, won: false)
+        2.times { create_receive_pattern(receive_style: chiquita_val, attack_style: :receive_ace, won: true) }
+        create_receive_pattern(receive_style: chiquita_val, attack_style: :receive_miss, won: false)
       end
 
-      it '正しくラベルを表示すること' do
+      it 'レシーブ技術別の直接決着率を返すこと' do
         analyzer = described_class.new(match_info)
-        result = analyzer.receive_style_stats
+        result = analyzer.receive_direct_stats
         expect(result).not_to be_empty
         chiquita_stat = result.find { |s| s[:label].include?('チキータ') }
         expect(chiquita_stat).not_to be_nil
         expect(chiquita_stat[:score]).to eq(2)
         expect(chiquita_stat[:lost_score]).to eq(1)
+        expect(chiquita_stat[:rate]).to eq(67)
+      end
+    end
+
+    context 'レシーブエース・ミス以外のパターンしかない場合' do
+      before do
+        chiquita_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita]
+        create_receive_pattern(receive_style: chiquita_val, attack_style: :fore_drive_vs_backspin, won: true)
+      end
+
+      it '空を返すこと' do
+        expect(described_class.new(match_info).receive_direct_stats).to be_empty
       end
     end
   end
@@ -137,35 +149,75 @@ RSpec.describe ServeReceiveAnalyzer do
   end
 
   describe '#decided_at_distribution' do
-    before do
-      2.times { create_serve_pattern(decided_at: :attack_ball, won: true) }
-      create_serve_pattern(decided_at: :follow_ball, won: false)
-      2.times { create_receive_pattern(decided_at: :rally, won: true) }
+    context '通常パターン（サービスエース・レシーブエースなし）の場合' do
+      before do
+        2.times { create_serve_pattern(decided_at: :attack_ball, won: true) }
+        create_serve_pattern(decided_at: :follow_ball, won: false)
+        2.times { create_receive_pattern(decided_at: :rally, won: true) }
+      end
+
+      it 'サーブ起点のラベルが3球目・5球目・7球目以降になること' do
+        analyzer = described_class.new(match_info)
+        dist = analyzer.decided_at_distribution
+        serve = dist[:serve]
+        expect(serve.find { |d| d[:label] == '3球目' }[:score]).to eq(2)
+        expect(serve.find { |d| d[:label] == '5球目' }[:lost_score]).to eq(1)
+        expect(serve.find { |d| d[:label] == '7球目以降' }[:score]).to eq(0)
+      end
+
+      it 'serve / receive が分離されること' do
+        analyzer = described_class.new(match_info)
+        dist = analyzer.decided_at_distribution
+        serve_dist = dist[:serve]
+        receive_dist = dist[:receive]
+
+        expect(serve_dist.find { |d| d[:label] == '3球目' }[:score]).to eq(2)
+        expect(receive_dist.find { |d| d[:label] == '8球目以降' }[:score]).to eq(2)
+      end
+
+      it '得点率が計算されること' do
+        analyzer = described_class.new(match_info)
+        dist = analyzer.decided_at_distribution
+        attack_ball = dist[:serve].find { |d| d[:label] == '3球目' }
+        expect(attack_ball[:rate]).to eq(100)
+      end
     end
 
-    it 'attack_ball / follow_ball / rally それぞれ集計されること' do
-      analyzer = described_class.new(match_info)
-      dist = analyzer.decided_at_distribution
-      all = dist[:all]
-      attack_ball = all.find { |d| d[:label] == '3・4球目' }
-      follow_ball = all.find { |d| d[:label] == '5・6球目' }
-      rally = all.find { |d| d[:label] == 'ラリー' }
-      expect(attack_ball[:score]).to eq(2)
-      expect(follow_ball[:lost_score]).to eq(1)
-      expect(rally[:score]).to eq(2)
+    context 'サービスエースがある場合' do
+      before do
+        create_serve_pattern(attack_style: :service_ace, decided_at: :attack_ball, won: true)
+        create_serve_pattern(decided_at: :attack_ball, won: true)
+      end
+
+      it '1球目が独立した行として集計されること' do
+        analyzer = described_class.new(match_info)
+        dist = analyzer.decided_at_distribution
+        first_ball = dist[:serve].find { |d| d[:label] == '1球目' }
+        third_ball = dist[:serve].find { |d| d[:label] == '3球目' }
+        expect(first_ball[:score]).to eq(1)
+        expect(third_ball[:score]).to eq(1)
+      end
     end
 
-    it 'serve / receive が分離されること' do
-      analyzer = described_class.new(match_info)
-      dist = analyzer.decided_at_distribution
-      serve_dist = dist[:serve]
-      receive_dist = dist[:receive]
+    context 'レシーブエース・ミスがある場合' do
+      before do
+        chiquita_val = ServeReceivePattern::RECEIVE_STYLE_VALUES[:chiquita]
+        create_receive_pattern(receive_style: chiquita_val, attack_style: :receive_ace,
+                               decided_at: :attack_ball, won: true)
+        create_receive_pattern(receive_style: chiquita_val, attack_style: :receive_miss,
+                               decided_at: :attack_ball, won: false)
+        create_receive_pattern(decided_at: :attack_ball, won: true)
+      end
 
-      serve_attack = serve_dist.find { |d| d[:label] == '3・4球目' }
-      expect(serve_attack[:score]).to eq(2)
-
-      receive_rally = receive_dist.find { |d| d[:label] == 'ラリー' }
-      expect(receive_rally[:score]).to eq(2)
+      it '2球目が独立した行として集計されること' do
+        analyzer = described_class.new(match_info)
+        dist = analyzer.decided_at_distribution
+        second_ball = dist[:receive].find { |d| d[:label] == '2球目' }
+        fourth_ball = dist[:receive].find { |d| d[:label] == '4球目' }
+        expect(second_ball[:score]).to eq(1)
+        expect(second_ball[:lost_score]).to eq(1)
+        expect(fourth_ball[:score]).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
## 概要

サーブ・レシーブ起点分析の専用分析ページを新規実装し、UIの表示品質を改善しました。

**Sprint 2（入力フロー）のPRに続くSprint 3の実装です。**

### 実装内容

**Sprint 3: 分析ページ本体**
- サーブ起点の分析（サーブ長さ別得点率・サーブ→3球目パターン別）
- レシーブ起点の分析（レシーブエース・ミス・レシーブ→4球目パターン別）
- 得点タイミング分布（サーブ起点・レシーブ起点）
  - 1球目（サービスエース）・2球目（レシーブエース・ミス）を独立行として集計
  - ラベルをサーブ起点（3球目/5球目/7球目以降）・レシーブ起点（4球目/6球目/8球目以降）で使い分け

**UI改善**
- テーブル全列1行表示：デスクトップは `overflow-auto` + `text-nowrap`、モバイルはラベル列のみ `text-wrap` + `min-width: 8rem`
- 並び順：サーブ長さ別（ショート→ハーフロング→ロング）、レシーブエース・ミス（得点数降順）
- 各テーブル直下に表示順の説明文を追加
- 詳細ページから編集ボタンを削除
- 一覧ページのボタンをスマホで縦並び・同幅に調整

## 確認方法

1. `bundle exec rails db:migrate` は不要（スキーマ変更なし）
2. サーブ・レシーブ分析を開始し、数ラリー分のデータを入力して保存
3. 試合分析詳細ページで各テーブルが正しく表示されることを確認
4. スマホ表示でテーブルが横スクロールなく読めることを確認
5. 試合分析一覧ページでボタンがスマホで縦並び・同幅になっていることを確認

## 影響範囲

- `match_infos#show`（サーブ・レシーブ分析表示）
- `match_infos#index`（ボタンレイアウト）
- `ServeReceiveAnalyzer`サービス（集計ロジック全般）
- `_serve_receive_score_table` パーシャル（全分析ページのテーブル表示）

## チェックリスト

- [x] RuboCop をパスした
- [x] RSpec をパスした（15 examples, 0 failures）

## コメント

- `decided_at_distribution` の `all` キーを削除し、サーブ/レシーブで異なるラベルを使うよう変更しました
- サービスエース・レシーブエースは従来 `attack_ball`（3・4球目）に混在していましたが、今回の実装で「1球目」「2球目」として独立した行に分離しています

Refs #77