### PR TITLE
fix: サーブ・レシーブ分析完了時にオートセーブの下書きをクリアする

### DIFF
--- a/app/views/match_infos/_serve_receive_form.html.erb
+++ b/app/views/match_infos/_serve_receive_form.html.erb
@@ -91,7 +91,8 @@
             data: { "serve-receive-input-target": "endGameBtn" } %>
       <% end %>
       <%= form.submit "🚀 試合を分析する",
-          class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow" %>
+          class: "btn btn-success px-4 py-2 mt-4 rounded-pill shadow",
+          data: { action: "click->auto-save#clearStorage" } %>
     </div>
 
     <% if draft_id.present? && saved_games.any? %>


### PR DESCRIPTION
## 概要

サーブ・レシーブ分析を作成した後、同じ内容のデータが下書きとして重複保存されることがある不具合を修正しました。

**原因:**
`auto_save_controller.js` は画面遷移時（`beforeunload`/`turbo:before-visit`）に入力中のデータを`localStorage`へ自動保存します。通常の試合分析フォーム（`_form.html.erb`）では「🚀 試合を分析する」ボタン押下時に `clearStorage` アクションでこの自動保存データを消去していますが、サーブ・レシーブ版フォーム（`_serve_receive_form.html.erb`）では同ボタンにこのアクションが設定されておらず（実装漏れ）、分析完了後もlocalStorageに直前の試合データが残ってしまっていました。

その結果、一覧画面で「下書きを復元しますか」バナーが表示され、ユーザーが復元操作をすると `restore_autosave` アクションが既存レコードをチェックせず常に新規MatchInfoを作成するため、直前に確定済みの試合と同一内容のデータが重複した下書きとして保存されていました。

**修正内容:**
`_serve_receive_form.html.erb` の「🚀 試合を分析する」ボタンに `data: { action: "click->auto-save#clearStorage" }` を追加し、通常版フォームと同様の挙動に揃えました。

## 確認方法

1. サーブ・レシーブ分析でいくつかゲームを入力し、30秒以上経過させる（オートセーブが走る状態にする）
2. 「🚀 試合を分析する」ボタンで分析を完了する
3. `/match_infos` 一覧画面を開き、「下書きを復元しますか」バナーが表示されないことを確認する

## 影響範囲

- `app/views/match_infos/_serve_receive_form.html.erb` のみ変更（サーブ・レシーブ分析フォームの最終送信ボタン）
- 通常の試合分析フォームには影響なし

## チェックリスト

- [x] `bundle exec rspec` をパスした（168 examples, 0 failures）
- [x] `bundle exec rubocop --parallel` をパスした（78 files inspected, no offenses detected）

## コメント

Heroku本番環境でのデプロイ後に発生した不具合調査の中で発見しました。

Closes #