### PR TITLE
fix: オートセーブのclearStorage直後にsaveStateで再書き込みされる不具合を修正

### DIFF
--- a/app/javascript/controllers/auto_save_controller.js
+++ b/app/javascript/controllers/auto_save_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
 
   connect() {
     this.STORAGE_KEY = "tt_log_autosave"
+    this.finalizing = false
 
     if (this.pageValue === "index") {
       this.checkAndShowBanner()
@@ -40,11 +41,15 @@ export default class extends Controller {
   }
 
   saveState() {
+    if (this.finalizing) return
+
     const data = this.collectFormData()
     localStorage.setItem(this.STORAGE_KEY, JSON.stringify(data))
   }
 
   clearStorage() {
+    this.finalizing = true
+    this.stopAutoSave()
     localStorage.removeItem(this.STORAGE_KEY)
   }
 


### PR DESCRIPTION
## 概要

#141 でサーブ・レシーブ版フォームの「🚀 試合を分析する」ボタンに `clearStorage` アクションを追加したが、それでも下書きの重複保存が解消しないという報告を受け、再調査した結果を修正。

**根本原因:**
`auto_save_controller.js` は `connect()` 時に `beforeunload` と `turbo:before-visit` の両方に `saveState()` をバインドしている。ボタンクリックで `clearStorage()` が実行され `localStorage` から自動保存データを削除しても、その直後に発生する Turbo Drive のページ遷移（`create_serve_receive` の302リダイレクト先へのvisit）で `turbo:before-visit` イベントが発火し、フォーム要素がまだDOM上に残っている（disconnectされる前の）タイミングで `saveState()` が再実行され、削除したはずのデータが同じ内容でそのまま書き戻されていた。

これは通常の試合分析フォーム（`_form.html.erb`）にも共通する構造的な問題で、`clearStorage` アクションが付いていても発生し得る。

**修正内容:**
`clearStorage()` 実行時に `finalizing` フラグを立てて自動保存タイマーを止め、`saveState()` 側でこのフラグが立っていたら即returnするようにガードを追加。これにより `clearStorage()` 実行後は `beforeunload`/`turbo:before-visit` が発火しても書き戻しが起きなくなる。

## 確認方法

1. サーブ・レシーブ分析でいくつかゲームを入力し、30秒以上経過させる（オートセーブが走る状態にする）
2. 「🚀 試合を分析する」ボタンで分析を完了する
3. `/match_infos` 一覧画面を開き、「下書きを復元しますか」バナーが表示されないことを確認する
4. 同様に通常の試合分析フォームでも重複下書きが発生しないことを確認する

## 影響範囲

- `app/javascript/controllers/auto_save_controller.js` のみ変更
- サーブ・レシーブ版・通常版どちらのフォームにも適用される（共通コントローラーのため）

## チェックリスト

- [x] `bundle exec rspec` をパスした（168 examples, 0 failures）
- [x] `bundle exec rubocop --parallel` をパスした（78 files inspected, no offenses detected）

## コメント

#141 は根本原因の一部（ボタンに`clearStorage`アクション自体が無かった）を修正したが、`clearStorage`実行後に`saveState`が再度呼ばれてしまう競合状態までは解消できていなかったため、今回追加で修正。

Closes #